### PR TITLE
Try to not crash when resolve throws

### DIFF
--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -114,10 +114,11 @@ fun KtClass.allSuperTypes(): List<KtClass> {
   return superTypes
 }
 
-fun PsiReference.safeResolve(): PsiElement? = runCatching {
-  resolve()
-}.onFailure { t ->
+fun PsiReference.safeResolve(): PsiElement? = try {
+  this.resolve()
+} catch (t: Throwable) {
   // Sometimes KotlinIdeaResolutionException or PsiInvalidElementAccessException unpredictably, just log it for now
   // But ControlFlowException is a normal thing to happen, so no need to log
   if (t !is ControlFlowException) logw(t, "Could not resolve $this")
-}.getOrNull()
+  null
+}


### PR DESCRIPTION
I still just got this:

```
org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Unable to resolve reference class org.jetbrains.kotlin.psi.KtNameReferenceExpression
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceResolver.resolve(KaFirReferenceResolver.kt:82)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceResolver.resolve(KaFirReferenceResolver.kt:24)
	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$resolveWithCaching$1(ResolveCache.java:167)
	at com.intellij.openapi.util.Computable.get(Computable.java:16)
	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$loggingResolver$4(ResolveCache.java:242)
	at com.intellij.openapi.util.Computable.get(Computable.java:16)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolve(ResolveCache.java:221)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:166)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:148)
	at org.jetbrains.kotlin.idea.references.AbstractKtReference.multiResolve(KtReference.kt:33)
	at com.intellij.psi.PsiPolyVariantReferenceBase.resolve(PsiPolyVariantReferenceBase.java:32)
	at com.apollographql.ijplugin.util.PsiKt.safeResolve(Psi.kt:118)
	at com.apollographql.ijplugin.util.PsiKt.resolveKtName(Psi.kt:68)
	at com.apollographql.ijplugin.navigation.GraphQLNavigationKt.isApolloOperationOrFragmentReference(GraphQLNavigation.kt:68)
	at com.apollographql.ijplugin.navigation.KotlinDefinitionMarkerProvider.collectNavigationMarkers(KotlinDefinitionMarkerProvider.kt:35)
	at com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider.collectNavigationMarkers(RelatedItemLineMarkerProvider.java:35)
	at com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider.collectSlowLineMarkers(RelatedItemLineMarkerProvider.java:27)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryProviders(LineMarkersPass.java:227)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.lambda$doCollectMarkers$2(LineMarkersPass.java:111)
	at com.intellij.codeInsight.daemon.impl.Divider.divideInsideAndOutsideInOneRoot(Divider.java:96)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectMarkers(LineMarkersPass.java:107)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectInformation(LineMarkersPass.java:79)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:71)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:435)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:29)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$3(PassExecutorService.java:431)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunReadAction(NestedLocksThreadingSupport.kt:826)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1221)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$4(PassExecutorService.java:421)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:681)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:756)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:712)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:680)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:420)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:395)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.cacheFileTypesInside(FileTypeManagerImpl.java:852)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$1(PassExecutorService.java:395)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:258)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:393)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:265)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: java.lang.NullPointerException: getOriginalFile(...) must not be null
	at org.jetbrains.kotlin.idea.util.FileUtils.getOriginalOrDelegateFile(FileUtils.kt:34)
	at org.jetbrains.kotlin.idea.fir.extensions.KtCompilerPluginsProviderIdeImpl.getRegisteredExtensions(KtCompilerPluginsProviderIdeImpl.kt:155)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.projectStructure.SessionFactoryHelpersKt.registerCompilerPluginExtensions(sessionFactoryHelpers.kt:97)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirAbstractSessionFactory.createScriptSession(LLFirAbstractSessionFactory.kt:161)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache.createSession(LLFirSessionCache.kt:128)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache.access$createSession(LLFirSessionCache.kt:28)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache$getSession$1.invoke(LLFirSessionCache.kt:60)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache$getSession$1.invoke(LLFirSessionCache.kt:60)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache.getCachedSession$lambda$3(LLFirSessionCache.kt:93)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.caches.cleanable.CleanableValueReferenceCache.computeIfAbsent$lambda$1(CleanableValueReferenceCache.kt:89)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.caches.cleanable.CleanableValueReferenceCache.compute$lambda$2(CleanableValueReferenceCache.kt:118)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.caches.cleanable.CleanableValueReferenceCache.compute$lambda$3(CleanableValueReferenceCache.kt:114)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.caches.cleanable.CleanableValueReferenceCache.compute(CleanableValueReferenceCache.kt:114)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.caches.cleanable.CleanableValueReferenceCache.computeIfAbsent(CleanableValueReferenceCache.kt:89)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache.getCachedSession(LLFirSessionCache.kt:93)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache.getSession(LLFirSessionCache.kt:60)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache.getSession$default(LLFirSessionCache.kt:49)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.LLResolutionFacadeService$getResolutionFacade$1.invoke(LLResolutionFacadeService.kt:24)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.LLResolutionFacadeService$getResolutionFacade$1.invoke(LLResolutionFacadeService.kt:24)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.state.LLSessionProvider.useSiteSession_delegate$lambda$0(LLSessionProvider.kt:22)
	at kotlin.SafePublicationLazyImpl.getValue(LazyJVM.kt:125)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.state.LLSessionProvider.getUseSiteSession(LLSessionProvider.kt:22)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLResolutionFacade.getUseSiteFirSession(LLResolutionFacade.kt:63)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider.createAnalysisSession(KaFirSessionProvider.kt:120)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider.access$createAnalysisSession(KaFirSessionProvider.kt:48)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider$getAnalysisSession$1.invoke(KaFirSessionProvider.kt:111)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider$getAnalysisSession$1.invoke(KaFirSessionProvider.kt:111)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider.getAnalysisSession$lambda$3(KaFirSessionProvider.kt:111)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2704)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2702)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2684)
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:112)
	at com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:63)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider.getAnalysisSession(KaFirSessionProvider.kt:111)
	at org.jetbrains.kotlin.analysis.api.fir.KaFirSessionProvider.getAnalysisSession(KaFirSessionProvider.kt:91)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceResolver.resolve(KaFirReferenceResolver.kt:61)
	... 45 more
```

I have no idea why `runCatching` wouldn't suffice, but let's try this instead.