### PR TITLE
Disable Kotlin inspections in non Kotlin files

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -89,6 +89,10 @@ tasks {
 
       // Enable K2 mode (can't be done in the UI in sandbox mode - see https://kotlin.github.io/analysis-api/testing-in-k2-locally.html)
       systemProperty("idea.kotlin.plugin.use.k2", "true")
+
+      jvmArgumentProviders += CommandLineArgumentProvider {
+        listOf("-Xmx4g")
+      }
     }
   }
 

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloInputConstructorNamedArgsInspection.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloInputConstructorNamedArgsInspection.kt
@@ -9,6 +9,7 @@ import com.apollographql.ijplugin.util.apollo3
 import com.apollographql.ijplugin.util.apollo4
 import com.apollographql.ijplugin.util.cast
 import com.apollographql.ijplugin.util.getParameterNames
+import com.apollographql.ijplugin.util.isInKotlinFile
 import com.apollographql.ijplugin.util.originalClassName
 import com.apollographql.ijplugin.util.registerProblem
 import com.apollographql.ijplugin.util.safeResolve
@@ -35,6 +36,7 @@ class ApolloInputConstructorNamedArgsInspection : LocalInspectionTool() {
     return object : KtVisitorVoid() {
       override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
+        if (!expression.isInKotlinFile()) return
         val projectApolloVersion = expression.project.apolloProjectService.apolloVersion
         if (!projectApolloVersion.isAtLeastV3) return
         val reference = expression.calleeExpression.cast<KtNameReferenceExpression>()

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspection.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspection.kt
@@ -10,6 +10,7 @@ import com.apollographql.ijplugin.util.canBeNull
 import com.apollographql.ijplugin.util.cast
 import com.apollographql.ijplugin.util.className
 import com.apollographql.ijplugin.util.getCalleeExpressionIfAny
+import com.apollographql.ijplugin.util.isInKotlinFile
 import com.apollographql.ijplugin.util.safeResolve
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemHighlightType
@@ -36,6 +37,7 @@ class ApolloOneOfInputCreationInspection : LocalInspectionTool() {
       // For constructor calls
       override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
+        if (!expression.isInKotlinFile()) return
         if (!expression.project.apolloProjectService.apolloVersion.isAtLeastV4) return
         val reference = (expression.calleeExpression.cast<KtNameReferenceExpression>())
         if (reference?.isApolloInputClassReference() != true) return
@@ -58,6 +60,7 @@ class ApolloOneOfInputCreationInspection : LocalInspectionTool() {
       // For builder calls
       override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
         super.visitDotQualifiedExpression(expression)
+        if (!expression.isInKotlinFile()) return
         if (!expression.project.apolloProjectService.apolloVersion.isAtLeastV4) return
         val expressionClass =
           expression.selectorExpression.getCalleeExpressionIfAny()?.mainReference?.safeResolve()?.parentOfType<KtClass>(withSelf = true)

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/intention/ApolloInputConstructorChangeToBuilderIntention.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/intention/ApolloInputConstructorChangeToBuilderIntention.kt
@@ -8,6 +8,7 @@ import com.apollographql.ijplugin.telemetry.TelemetryEvent
 import com.apollographql.ijplugin.telemetry.telemetryService
 import com.apollographql.ijplugin.util.cast
 import com.apollographql.ijplugin.util.getParameterNames
+import com.apollographql.ijplugin.util.isInKotlinFile
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
 import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils
 import com.intellij.openapi.editor.Editor
@@ -23,6 +24,7 @@ class ApolloInputConstructorChangeToBuilderIntention : PsiElementBaseIntentionAc
 
   override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
     if (!element.project.apolloProjectService.apolloVersion.isAtLeastV4) return false
+    if (!element.isInKotlinFile()) return false
     val callExpression = (element as? LeafPsiElement)?.parent?.parent as? KtCallExpression ?: return false
     val reference = callExpression.calleeExpression.cast<KtNameReferenceExpression>() ?: return false
     return reference.isApolloInputClassReference()

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinDefinitionMarkerProvider.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinDefinitionMarkerProvider.kt
@@ -5,6 +5,7 @@ import com.apollographql.ijplugin.icons.ApolloIcons
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.telemetry.TelemetryEvent
 import com.apollographql.ijplugin.telemetry.telemetryService
+import com.apollographql.ijplugin.util.isInKotlinFile
 import com.apollographql.ijplugin.util.originalClassName
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
@@ -27,6 +28,7 @@ class KotlinDefinitionMarkerProvider : RelatedItemLineMarkerProvider() {
   override fun getIcon() = ApolloIcons.Gutter.GraphQL
 
   override fun collectNavigationMarkers(element: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<*>>) {
+    if (!element.isInKotlinFile()) return
     if (!element.project.apolloProjectService.apolloVersion.isAtLeastV3) return
 
     val nameReferenceExpression = element as? KtNameReferenceExpression ?: return

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinTypeDeclarationProvider.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinTypeDeclarationProvider.kt
@@ -20,7 +20,7 @@ class KotlinTypeDeclarationProvider : TypeDeclarationProvider {
 
     // Get the original declaration(s)
     val ktTypeDeclarations = TypeDeclarationProvider.EP_NAME.extensionList.filterNot { it is KotlinTypeDeclarationProvider }
-        .map { it.getSymbolTypeDeclarations(symbol) }.filterNotNull().firstOrNull()
+        .firstNotNullOfOrNull { it.getSymbolTypeDeclarations(symbol) }
     val ktTypeDeclaration = ktTypeDeclarations?.firstOrNull() ?: return null
 
     val gqlElements = when {

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.idea.refactoring.isInjectedFragment
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.name.FqName
@@ -121,4 +122,9 @@ fun PsiReference.safeResolve(): PsiElement? = try {
   // But ControlFlowException is a normal thing to happen, so no need to log
   if (t !is ControlFlowException) logw(t, "Could not resolve $this")
   null
+}
+
+fun PsiElement.isInKotlinFile(): Boolean {
+  val containingKtFile = containingKtFile() ?: return false
+  return !containingKtFile.isInjectedFragment
 }


### PR DESCRIPTION
Because `resolve()` sometimes 'randomly' crashes in this case.

```
org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Unable to resolve reference class org.jetbrains.kotlin.psi.KtNameReferenceExpression
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceResolver.resolve(KaFirReferenceResolver.kt:82)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceResolver.resolve(KaFirReferenceResolver.kt:24)
	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$resolveWithCaching$1(ResolveCache.java:167)
	at com.intellij.openapi.util.Computable.get(Computable.java:16)
	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$loggingResolver$4(ResolveCache.java:242)
	at com.intellij.openapi.util.Computable.get(Computable.java:16)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolve(ResolveCache.java:221)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:166)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:148)
	at org.jetbrains.kotlin.idea.references.AbstractKtReference.multiResolve(KtReference.kt:33)
	at com.intellij.psi.PsiPolyVariantReferenceBase.resolve(PsiPolyVariantReferenceBase.java:32)
	at com.apollographql.ijplugin.util.PsiKt.safeResolve(Psi.kt:118)
	at com.apollographql.ijplugin.util.PsiKt.resolveKtName(Psi.kt:68)
	at com.apollographql.ijplugin.navigation.GraphQLNavigationKt.isApolloOperationOrFragmentReference(GraphQLNavigation.kt:68)
	at com.apollographql.ijplugin.navigation.KotlinDefinitionMarkerProvider.collectNavigationMarkers(KotlinDefinitionMarkerProvider.kt:35)
	at com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider.collectNavigationMarkers(RelatedItemLineMarkerProvider.java:35)
	at com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider.collectSlowLineMarkers(RelatedItemLineMarkerProvider.java:27)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryProviders(LineMarkersPass.java:227)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.lambda$queryLineMarkersForInjected$8(LineMarkersPass.java:267)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.probeElementsUpInner(InjectedLanguageUtilBase.java:252)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.lambda$probeElementsUp$0(InjectedLanguageUtilBase.java:218)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl$allowInWriteAction$1.invoke(ReadActionCacheImpl.kt:41)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl$allowInWriteAction$1.invoke(ReadActionCacheImpl.kt:41)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl.allowInWriteAction(ReadActionCacheImpl.kt:29)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl.allowInWriteAction(ReadActionCacheImpl.kt:41)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.probeElementsUp(InjectedLanguageUtilBase.java:217)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.enumerate(InjectedLanguageUtilBase.java:160)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.enumerateEx(InjectedLanguageManagerImpl.java:394)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryLineMarkersForInjected(LineMarkersPass.java:259)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryProviders(LineMarkersPass.java:218)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.lambda$doCollectMarkers$2(LineMarkersPass.java:111)
	at com.intellij.codeInsight.daemon.impl.Divider.divideInsideAndOutsideInOneRoot(Divider.java:96)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectMarkers(LineMarkersPass.java:107)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectInformation(LineMarkersPass.java:79)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:71)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:435)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:29)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$3(PassExecutorService.java:431)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunReadAction(NestedLocksThreadingSupport.kt:826)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1221)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$4(PassExecutorService.java:421)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:681)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:756)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:712)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:680)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:420)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:395)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.cacheFileTypesInside(FileTypeManagerImpl.java:852)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$1(PassExecutorService.java:395)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:258)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:393)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:265)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: com.intellij.psi.PsiInvalidElementAccessException: Element class com.intellij.psi.impl.source.tree.CompositeElement of type PROPERTY (class org.jetbrains.kotlin.psi.stubs.elements.KtPropertyElementType)
	at com.intellij.psi.PsiInvalidElementAccessException.createByNode(PsiInvalidElementAccessException.java:80)
	at com.intellij.psi.impl.source.SubstrateRef$2.getContainingFile(SubstrateRef.java:73)
	at com.intellij.extapi.psi.StubBasedPsiElementBase.getContainingFile(StubBasedPsiElementBase.java:243)
	at org.jetbrains.kotlin.psi.KtElementImplStub.getContainingKtFile(KtElementImplStub.java:59)
	at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirPsiSymbolKt.getCameFromKotlinLibrary(KaFirPsiSymbol.kt:214)
	at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirPsiSymbolKt.psiOrSymbolOrigin(KaFirPsiSymbol.kt:209)
	at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirKtBasedSymbol.getOrigin(KaFirPsiSymbol.kt:81)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceKt.getPsiDeclarations(KaFirReference.kt:85)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReference.getResolvedToPsi(KaFirReference.kt:42)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirSimpleNameReference.getResolvedToPsi(KaFirSimpleNameReference.kt:61)
	at org.jetbrains.kotlin.analysis.api.fir.references.KaFirReferenceResolver.resolve(KaFirReferenceResolver.kt:36)
	... 57 more
```

See also https://youtrack.jetbrains.com/issue/KTIJ-35921