### PR TITLE
Avoid com.android.tools.idea.adb APIs, prefer adblib ones

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -45,10 +45,6 @@ fun getVersionName(): String {
   }
 }
 
-kotlin {
-  jvmToolchain(21)
-}
-
 // Copy specific dependencies to a directory visible to the unit tests.
 // See ApolloTestCase.kt.
 configurations {
@@ -124,6 +120,22 @@ tasks.register("downloadMockJdk") {
               .readBytes()
       )
     }
+  }
+}
+
+// Generate a Version.kt file with a constant for the version name
+val generateVersionKtTask = tasks.register("generateVersionKt") {
+  val outputDir = layout.buildDirectory.dir("generated/source/kotlin").get().asFile
+  outputs.dir(outputDir)
+  val v = version
+  doFirst {
+    val outputWithPackageDir = File(outputDir, "com/apollographql/ijplugin").apply { mkdirs() }
+    File(outputWithPackageDir, "Version.kt").writeText(
+        """
+        package com.apollographql.ijplugin
+        internal const val VERSION = "$v"
+        """.trimIndent()
+    )
   }
 }
 
@@ -290,5 +302,14 @@ intellijPlatform {
             PLUGIN_STRUCTURE_WARNINGS,
         )
     )
+  }
+}
+
+kotlin {
+  jvmToolchain(21)
+  sourceSets {
+    main {
+      kotlin.srcDir(generateVersionKtTask)
+    }
   }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.extensions.excludeCoroutines
-import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.INVALID_PLUGIN
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS
@@ -285,7 +284,7 @@ intellijPlatform {
         setOf(
             // Commenting for now, because of https://platform.jetbrains.com/t/structure-view-impl-package-not-found/4388
             // TODO uncomment when a solution is found
-            COMPATIBILITY_PROBLEMS,
+//            COMPATIBILITY_PROBLEMS,
             INTERNAL_API_USAGES,
             INVALID_PLUGIN,
             PLUGIN_STRUCTURE_WARNINGS,

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -283,6 +283,8 @@ intellijPlatform {
     }
     failureLevel.set(
         setOf(
+            // Commenting for now, because of https://platform.jetbrains.com/t/structure-view-impl-package-not-found/4388
+            // TODO uncomment when a solution is found
             COMPATIBILITY_PROBLEMS,
             INTERNAL_API_USAGES,
             INVALID_PLUGIN,

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/apollodebugserver/ApolloDebugClient.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/apollodebugserver/ApolloDebugClient.kt
@@ -1,7 +1,8 @@
 package com.apollographql.ijplugin.apollodebugserver
 
-import com.android.ddmlib.IDevice
-import com.android.tools.idea.adb.AdbShellCommandsUtil
+import com.android.adblib.ConnectedDevice
+import com.android.adblib.SocketSpec
+import com.android.adblib.selector
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
@@ -10,18 +11,20 @@ import com.apollographql.apollo.network.NetworkTransport
 import com.apollographql.apollo.network.http.LoggingInterceptor
 import com.apollographql.ijplugin.util.apollo3
 import com.apollographql.ijplugin.util.apollo4
-import com.apollographql.ijplugin.util.executeCatching
+import com.apollographql.ijplugin.util.executeShellCommandCatching
+import com.apollographql.ijplugin.util.isError
 import com.apollographql.ijplugin.util.logd
 import com.apollographql.ijplugin.util.logw
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
 import java.io.Closeable
 
 private const val SOCKET_NAME_PREFIX = "apollo_debug_"
 private const val BASE_PORT = 12200
 
 class ApolloDebugClient(
-    private val device: IDevice,
+    private val device: ConnectedDevice,
     val packageName: String,
 ) : Closeable {
   companion object {
@@ -31,8 +34,8 @@ class ApolloDebugClient(
       return BASE_PORT + uniquePort++
     }
 
-    private fun IDevice.getApolloDebugPackageList(): Result<List<String>> {
-      val commandResult = AdbShellCommandsUtil.create(this).executeCatching("cat /proc/net/unix | grep $SOCKET_NAME_PREFIX | cat")
+    private fun ConnectedDevice.getApolloDebugPackageList(): Result<List<String>> {
+      val commandResult = executeShellCommandCatching("cat /proc/net/unix | grep $SOCKET_NAME_PREFIX | cat")
       if (commandResult.isFailure) {
         val e = commandResult.exceptionOrNull()!!
         logw(e, "Could not list Apollo Debug packages")
@@ -40,13 +43,13 @@ class ApolloDebugClient(
       }
       val result = commandResult.getOrThrow()
       if (result.isError) {
-        val message = "Could not list Apollo Debug packages: ${result.output.joinToString()}"
+        val message = "Could not list Apollo Debug packages: ${result.stderr}"
         logw(message)
         return Result.failure(Exception(message))
       }
       // Results are in the form:
       // 0000000000000000: 00000002 00000000 00010000 0001 01 116651 @apollo_debug_com.example.myapplication
-      val packageList = result.output
+      val packageList = result.stdout.lines()
           .filter { it.contains(SOCKET_NAME_PREFIX) }
           .map { it.substringAfterLast(SOCKET_NAME_PREFIX) }
           .sorted()
@@ -54,7 +57,7 @@ class ApolloDebugClient(
       return Result.success(packageList)
     }
 
-    fun IDevice.getApolloDebugClients(): Result<List<ApolloDebugClient>> {
+    fun ConnectedDevice.getApolloDebugClients(): Result<List<ApolloDebugClient>> {
       return getApolloDebugPackageList().map { packageNames ->
         packageNames.map { packageName ->
           ApolloDebugClient(this, packageName)
@@ -80,10 +83,14 @@ class ApolloDebugClient(
       })
       .build()
 
-  private fun createPortForward() {
+  private suspend fun createPortForward() {
     logd("Creating port forward to $port for $packageName")
     try {
-      device.createForward(port, "$SOCKET_NAME_PREFIX$packageName", IDevice.DeviceUnixSocketNamespace.ABSTRACT)
+      device.session.hostServices.forward(
+          device = device.selector,
+          local = SocketSpec.Tcp(port),
+          remote = SocketSpec.LocalAbstract("$SOCKET_NAME_PREFIX$packageName"),
+      )
     } catch (e: Exception) {
       logw(e, "Could not create port forward to $port for $packageName")
       throw e
@@ -91,17 +98,17 @@ class ApolloDebugClient(
     hasPortForward = true
   }
 
-  private fun removePortForward() {
+  private suspend fun removePortForward() {
     logd("Removing port forward to $port for $packageName")
     try {
-      device.removeForward(port)
+      device.session.hostServices.killForward(device.selector, SocketSpec.Tcp(port))
     } catch (e: Exception) {
       logw(e, "Could not remove port forward to $port for $packageName")
     }
     hasPortForward = false
   }
 
-  private fun ensurePortForward() {
+  private suspend fun ensurePortForward() {
     if (!hasPortForward) {
       createPortForward()
     }
@@ -117,13 +124,14 @@ class ApolloDebugClient(
       normalizedCacheId: String,
   ): Result<GetNormalizedCacheQuery.NormalizedCache> = runCatching {
     ensurePortForward()
-    apolloClient.query(GetNormalizedCacheQuery(apolloClientId, normalizedCacheId)).execute().dataOrThrow().apolloClient?.normalizedCache
+    apolloClient.query(GetNormalizedCacheQuery(apolloClientId, normalizedCacheId)).execute()
+        .dataOrThrow().apolloClient?.normalizedCache
         ?: error("No normalized cache returned by server")
   }
 
   override fun close() {
     if (hasPortForward) {
-      removePortForward()
+      runBlocking { removePortForward() }
     }
     apolloClient.close()
   }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/error/GitHubIssueErrorReportSubmitter.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/error/GitHubIssueErrorReportSubmitter.kt
@@ -1,14 +1,13 @@
 package com.apollographql.ijplugin.error
 
 import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.VERSION
 import com.apollographql.ijplugin.util.urlEncoded
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.ex.ApplicationInfoEx
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.Consumer
 import java.awt.Component
@@ -31,7 +30,7 @@ class GitHubIssueErrorReportSubmitter : ErrorReportSubmitter() {
     val ideNameAndVersion = ApplicationInfoEx.getInstanceEx().let { appInfo ->
       appInfo.fullApplicationName + "  " + "Build #" + appInfo.build.asString()
     }
-    val pluginVersion = PluginManagerCore.getPlugin(PluginId.getId("com.apollographql.ijplugin"))?.version ?: "unknown"
+    val pluginVersion = VERSION
     val properties = System.getProperties()
     val jdk = properties.getProperty("java.version", "unknown") +
         "; VM: " + properties.getProperty("java.vm.name", "unknown") +

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspection.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspection.kt
@@ -19,7 +19,7 @@ import com.intellij.lang.jsgraphql.psi.GraphQLInputObjectTypeDefinition
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.util.findTopmostParentOfType
 import com.intellij.psi.util.parentOfType
-import org.jetbrains.kotlin.idea.intentions.branchedTransformations.isNullExpression
+import org.jetbrains.kotlin.idea.base.psi.isNullExpression
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/NormalizedCacheSource.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/NormalizedCacheSource.kt
@@ -1,6 +1,6 @@
 package com.apollographql.ijplugin.normalizedcache
 
-import com.android.ddmlib.IDevice
+import com.android.adblib.ConnectedDevice
 import com.apollographql.ijplugin.apollodebugserver.ApolloDebugClient
 import java.io.File
 
@@ -8,7 +8,7 @@ sealed interface NormalizedCacheSource {
   data class LocalFile(val file: File) : NormalizedCacheSource
 
   data class DeviceFile(
-      val device: IDevice,
+      val device: ConnectedDevice,
       val packageName: String,
       val remoteDirName: String,
       val remoteFileName: String,

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/PullFromDevice.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/PullFromDevice.kt
@@ -1,25 +1,28 @@
 package com.apollographql.ijplugin.normalizedcache
 
+import com.android.adblib.ConnectedDevice
 import com.android.adblib.DeviceSelector
+import com.android.adblib.connectedDevicesTracker
+import com.android.adblib.serialNumber
 import com.android.adblib.syncRecv
-import com.android.ddmlib.AndroidDebugBridge
-import com.android.ddmlib.IDevice
-import com.android.tools.idea.adb.AdbShellCommandsUtil
 import com.android.tools.idea.adblib.AdbLibApplicationService
-import com.apollographql.ijplugin.util.execute
-import com.apollographql.ijplugin.util.executeCatching
+import com.apollographql.ijplugin.util.executeShellCommand
+import com.apollographql.ijplugin.util.executeShellCommandCatching
+import com.apollographql.ijplugin.util.isError
 import com.apollographql.ijplugin.util.logd
 import com.apollographql.ijplugin.util.logw
 import java.io.File
 import java.nio.file.Paths
-import java.util.concurrent.TimeUnit
 
-fun getConnectedDevices(): List<IDevice> {
-  return AndroidDebugBridge.createBridge(1, TimeUnit.SECONDS).devices.sortedBy { it.name }
+fun getConnectedDevices(): List<ConnectedDevice> {
+  return AdbLibApplicationService.instance.session
+      .connectedDevicesTracker
+      .connectedDevices.value
+      .sortedBy { it.serialNumber }
 }
 
-fun IDevice.getDebuggablePackageList(): Result<List<String>> {
-  val commandResult = AdbShellCommandsUtil.create(this).executeCatching(
+fun ConnectedDevice.getDebuggablePackageList(): Result<List<String>> {
+  val commandResult = executeShellCommandCatching(
       // List all packages, and try run-as on them - if it succeeds, the package is debuggable
       "for p in \$(pm list packages -3 | cut -d : -f 2); do (run-as \$p true >/dev/null 2>&1 && echo \$p); done; true"
   )
@@ -30,15 +33,15 @@ fun IDevice.getDebuggablePackageList(): Result<List<String>> {
   }
   val result = commandResult.getOrThrow()
   if (result.isError) {
-    val message = "Could not list debuggable packages: ${result.output.joinToString()}"
+    val message = "Could not list debuggable packages: ${result.stderr}"
     logw(message)
     return Result.failure(Exception(message))
   }
-  return Result.success(result.output.filterNot { it.isEmpty() }.sorted())
+  return Result.success(result.stdout.lines().filterNot { it.isEmpty() }.sorted())
 }
 
-fun IDevice.getDatabaseList(packageName: String, databasesDir: String): Result<List<String>> {
-  val commandResult = AdbShellCommandsUtil.create(this).executeCatching("run-as $packageName ls -1 $databasesDir")
+fun ConnectedDevice.getDatabaseList(packageName: String, databasesDir: String): Result<List<String>> {
+  val commandResult = executeShellCommandCatching("run-as $packageName ls -1 $databasesDir")
   if (commandResult.isFailure) {
     val e = commandResult.exceptionOrNull()!!
     logw(e, "Could not list databases")
@@ -46,17 +49,17 @@ fun IDevice.getDatabaseList(packageName: String, databasesDir: String): Result<L
   }
   val result = commandResult.getOrThrow()
   if (result.isError) {
-    if (result.output.any { it.contains("No such file or directory") }) {
+    if (result.stderr.contains("No such file or directory") || result.stdout.contains("No such file or directory")) {
       return Result.success(emptyList())
     }
-    val message = "Could not list databases: ${result.output.joinToString()}"
+    val message = "Could not list databases: ${result.stderr}"
     logw(message)
     return Result.failure(Exception(message))
   }
-  return Result.success(result.output.filter { it.isDatabaseFileName() }.sorted())
+  return Result.success(result.stdout.lines().filter { it.isDatabaseFileName() }.sorted())
 }
 
-fun IDevice.getDatabaseList(packageName: String, databasesDirs: List<String>): Result<List<Pair<String, String>>> {
+fun ConnectedDevice.getDatabaseList(packageName: String, databasesDirs: List<String>): Result<List<Pair<String, String>>> {
   val allDatabases = mutableListOf<Pair<String, String>>()
   var atLeastOneSuccess = false
   for (databasesDir in databasesDirs) {
@@ -74,18 +77,17 @@ fun IDevice.getDatabaseList(packageName: String, databasesDirs: List<String>): R
   }
 }
 
-suspend fun pullFile(device: IDevice, appPackageName: String, remoteDirName: String, remoteFileName: String): Result<File> {
+suspend fun pullFile(device: ConnectedDevice, appPackageName: String, remoteDirName: String, remoteFileName: String): Result<File> {
   val remoteFilePath = "$remoteDirName/$remoteFileName"
   val localFile = File.createTempFile(remoteFileName.substringBeforeLast(".") + "-tmp", ".db")
   logd("Pulling $remoteFilePath to ${localFile.absolutePath}")
   val intermediateRemoteFilePath = "/data/local/tmp/${localFile.name}"
-  val shellCommandsUtil = AdbShellCommandsUtil.create(device)
   return runCatching {
-    var commandResult = shellCommandsUtil.execute("touch $intermediateRemoteFilePath")
+    var commandResult = device.executeShellCommand("touch $intermediateRemoteFilePath")
     if (commandResult.isError) {
       throw Exception("'touch' command failed")
     }
-    commandResult = shellCommandsUtil.execute("run-as $appPackageName sh -c 'cp $remoteFilePath $intermediateRemoteFilePath'")
+    commandResult = device.executeShellCommand("run-as $appPackageName sh -c 'cp $remoteFilePath $intermediateRemoteFilePath'")
     if (commandResult.isError) {
       throw Exception("'copy' command failed")
     }
@@ -96,7 +98,7 @@ suspend fun pullFile(device: IDevice, appPackageName: String, remoteDirName: Str
         adbLibSession.deviceServices.syncRecv(DeviceSelector.fromSerialNumber(device.serialNumber), intermediateRemoteFilePath, fileChannel)
       }
     } finally {
-      commandResult = shellCommandsUtil.execute("rm $intermediateRemoteFilePath")
+      commandResult = device.executeShellCommand("rm $intermediateRemoteFilePath")
       if (commandResult.isError) {
         logw("'rm' command failed")
       }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/PullFromDeviceDialog.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/PullFromDeviceDialog.kt
@@ -1,8 +1,9 @@
 package com.apollographql.ijplugin.normalizedcache
 
 import android.annotation.SuppressLint
-import com.android.ddmlib.Client
-import com.android.ddmlib.IDevice
+import com.android.adblib.ConnectedDevice
+import com.android.adblib.deviceInfo
+import com.android.adblib.serialNumber
 import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.apollodebugserver.ApolloDebugClient
 import com.apollographql.ijplugin.apollodebugserver.ApolloDebugClient.Companion.getApolloDebugClients
@@ -174,70 +175,41 @@ class PullFromDeviceDialog(
     }
   }
 
-  private inner class DeviceNode(project: Project, parent: DynamicNode, private val device: IDevice) : DynamicNode(project, parent) {
+  private inner class DeviceNode(project: Project, parent: DynamicNode, private val device: ConnectedDevice) :
+    DynamicNode(project, parent) {
     init {
-      myName = device.name
-      icon = if (device.isEmulator) StudioIcons.DeviceExplorer.VIRTUAL_DEVICE_PHONE else StudioIcons.DeviceExplorer.PHYSICAL_DEVICE_PHONE
+      myName = device.deviceInfo.model?.let { model -> "${device.serialNumber} ($model)" } ?: device.serialNumber
+      icon =
+        if (myName.contains("emulator", ignoreCase = true)) StudioIcons.DeviceExplorer.VIRTUAL_DEVICE_PHONE else StudioIcons.DeviceExplorer.PHYSICAL_DEVICE_PHONE
     }
 
     override fun computeChildren() {
       val apolloDebugClients: List<ApolloDebugClient> = device.getApolloDebugClients().getOrDefault(emptyList())
       apolloDebugClientsToClose.addAll(apolloDebugClients)
-      val clients: List<Client> = device.clients
-          .filter { client ->
-            client.isValid &&
-                client.clientData.packageName != null &&
-                // If a package has the Apollo Debug running, don't show it as a database package
-                client.clientData.packageName !in apolloDebugClients.map { it.packageName }
-          }
-          .sortedBy { it.clientData.packageName }
-
-      val allClients = (apolloDebugClients + clients).sortedBy {
-        when (it) {
-          is ApolloDebugClient -> it.packageName
-          is Client -> it.clientData.packageName
-          else -> throw IllegalStateException()
-        }
-      }
+      val apolloDebugPackageNames = apolloDebugClients.map { it.packageName }.toSet()
+      val autoExpand = apolloDebugClients.size <= 4
 
       updateChildren(
           buildList {
-            val autoExpand = allClients.size <= 4
-
-            // Add running apps
             addAll(
-                allClients.map { client ->
-                  when (client) {
-                    is ApolloDebugClient -> ApolloDebugPackageNode(
-                        project = project,
-                        parent = this@DeviceNode,
-                        apolloDebugClient = client,
-                        computeChildrenOn = ComputeChildrenOn.INIT,
-                        autoExpand = autoExpand,
-                    )
-
-                    is Client -> {
-                      val packageName = client.clientData.packageName
-                      val databasesDir =
-                        listOf(client.clientData.dataDir + "/databases", client.clientData.dataDir + "/cache", client.clientData.dataDir + "/no_backup")
-                      DatabasePackageNode(
-                          project = project,
-                          parent = this@DeviceNode,
-                          device = device,
-                          packageName = packageName,
-                          databasesDirs = databasesDir,
-                          computeChildrenOn = ComputeChildrenOn.INIT,
-                          autoExpand = autoExpand,
-                      )
-                    }
-
-                    else -> throw IllegalStateException()
-                  }
+                apolloDebugClients.map { client ->
+                  ApolloDebugPackageNode(
+                      project = project,
+                      parent = this@DeviceNode,
+                      apolloDebugClient = client,
+                      computeChildrenOn = ComputeChildrenOn.INIT,
+                      autoExpand = autoExpand,
+                  )
                 }
             )
-
-            // Add other debuggable apps
-            add(DebuggablePackagesNode(project, this@DeviceNode, device))
+            add(
+                DebuggablePackagesNode(
+                    project = project,
+                    parent = this@DeviceNode,
+                    device = device,
+                    excludePackageNames = apolloDebugPackageNames
+                )
+            )
           }
       )
     }
@@ -250,7 +222,8 @@ class PullFromDeviceDialog(
   private inner class DebuggablePackagesNode(
       project: Project,
       parent: DynamicNode,
-      private val device: IDevice,
+      private val device: ConnectedDevice,
+      private val excludePackageNames: Set<String> = emptySet(),
   ) : DynamicNode(project, parent) {
     init {
       myName = ApolloBundle.message("normalizedCacheViewer.pullFromDevice.listDebuggablePackages.title")
@@ -261,12 +234,13 @@ class PullFromDeviceDialog(
       device.getDebuggablePackageList().onFailure {
         logw(it, "Could not list debuggable packages")
         updateChild(ErrorNode((ApolloBundle.message("normalizedCacheViewer.pullFromDevice.listDebuggablePackages.error"))))
-      }.onSuccess {
-        if (it.isEmpty()) {
+      }.onSuccess { allPackages ->
+        val packages = allPackages.filterNot { it in excludePackageNames }
+        if (packages.isEmpty()) {
           updateChild(EmptyNode(ApolloBundle.message("normalizedCacheViewer.pullFromDevice.listDebuggablePackages.empty")))
         } else {
           updateChildren(
-              it.map { packageName ->
+              packages.map { packageName ->
                 DatabasePackageNode(
                     project = project,
                     parent = this,
@@ -286,7 +260,7 @@ class PullFromDeviceDialog(
   private inner class DatabasePackageNode(
       project: Project,
       parent: DynamicNode,
-      private val device: IDevice,
+      private val device: ConnectedDevice,
       private val packageName: String,
       private val databasesDirs: List<String>,
       computeChildrenOn: ComputeChildrenOn,
@@ -369,7 +343,7 @@ class PullFromDeviceDialog(
   }
 
   private inner class DatabaseNode(
-      val device: IDevice,
+      val device: ConnectedDevice,
       val packageName: String,
       val databasesDir: String,
       val databaseFileName: String,

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
@@ -33,9 +33,10 @@ import javax.swing.Action
 class ApolloProjectActivity : ProjectActivity {
   override suspend fun execute(project: Project) {
     logd()
-    val descriptor = PluginManagerCore.getPlugin(PluginId.getId("com.intellij.lang.jsgraphql"))
-    logd("com.intellij.lang.jsgraphql isEnabled=${descriptor?.isEnabled}")
-    if (descriptor?.isEnabled == true) {
+    val isJsgraphqlPluginInstalled = PluginManagerCore.isPluginInstalled(PluginId.getId("com.intellij.lang.jsgraphql"))
+    val isJsgraphqlPluginDisabled = PluginManagerCore.isDisabled(PluginId.getId("com.intellij.lang.jsgraphql"))
+    logd("isJsgraphqlPluginInstalled=$isJsgraphqlPluginInstalled isJsgraphqlPluginDisabled=$isJsgraphqlPluginDisabled")
+    if (isJsgraphqlPluginInstalled && !isJsgraphqlPluginDisabled) {
       runInEdt {
         IncompatiblePluginDialog(project).show()
       }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.telemetry
 
 import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.VERSION
 import com.apollographql.ijplugin.icons.ApolloIcons
 import com.apollographql.ijplugin.project.ApolloProjectListener
 import com.apollographql.ijplugin.project.ApolloProjectService.ApolloVersion
@@ -26,7 +27,6 @@ import com.apollographql.ijplugin.util.getLibraryMavenCoordinates
 import com.apollographql.ijplugin.util.logd
 import com.apollographql.ijplugin.util.logw
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
@@ -34,7 +34,6 @@ import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.ex.ApplicationInfoEx
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.profile.codeInspection.ProjectInspectionProfileManager
 import com.intellij.util.application
@@ -130,7 +129,7 @@ class TelemetryService(
     }
     add(IdeVersion(appName))
     System.getProperties().getProperty("os.name")?.let { add(TelemetryProperty.IdeOS(it)) }
-    PluginManagerCore.getPlugin(PluginId.getId("com.apollographql.ijplugin"))?.version?.let { add(ApolloIjPluginVersion(it)) }
+    add(ApolloIjPluginVersion(VERSION))
     add(ApolloIjPluginAutomaticCodegenTriggering(project.projectSettingsState.automaticCodegenTriggering))
     add(ApolloIjPluginContributeConfigurationToGraphqlPlugin(project.projectSettingsState.contributeConfigurationToGraphqlPlugin))
     add(ApolloIjPluginHasConfiguredGraphOsApiKeys(project.projectSettingsState.apolloKotlinServiceConfigurations.isNotEmpty()))

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Adb.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Adb.kt
@@ -1,16 +1,19 @@
 package com.apollographql.ijplugin.util
 
-import com.android.tools.idea.adb.AdbShellCommandResult
-import com.android.tools.idea.adb.AdbShellCommandsUtil
+import com.android.adblib.ConnectedDevice
+import com.android.adblib.ShellCommandOutput
+import com.android.adblib.shell
 import kotlinx.coroutines.runBlocking
 
-fun AdbShellCommandsUtil.execute(command: String): AdbShellCommandResult {
+suspend fun ConnectedDevice.executeShellCommand(command: String): ShellCommandOutput {
   logd("Executing adb shell command: '$command'")
-  val result = runBlocking { executeCommand(command) }
-  logd("adb shell command result: isError=${result.isError}, isEmpty=${result.isEmpty}, output=${result.output.joinToString("\n")}")
-  return result
+  val output = shell.executeAsText(command)
+  logd("adb shell command result: exitCode=${output.exitCode}, stdout=${output.stdout}, stderr=${output.stderr}")
+  return output
 }
 
-fun AdbShellCommandsUtil.executeCatching(command: String): Result<AdbShellCommandResult> = runCatching {
-  execute(command)
+fun ConnectedDevice.executeShellCommandCatching(command: String): Result<ShellCommandOutput> = runCatching {
+  runBlocking { executeShellCommand(command) }
 }
+
+val ShellCommandOutput.isError: Boolean get() = exitCode != 0

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Environment.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Environment.kt
@@ -2,7 +2,7 @@ package com.apollographql.ijplugin.util
 
 val isLspAvailable = runCatching { Class.forName("com.intellij.platform.lsp.api.LspServerManager") }.isSuccess
 
-val isAndroidPluginPresent = runCatching { Class.forName("com.android.ddmlib.AndroidDebugBridge") }.isSuccess
+val isAndroidPluginPresent = runCatching { Class.forName("com.android.adblib.AdbSession") }.isSuccess
 
 val isJavaPluginPresent = runCatching { Class.forName("com.intellij.psi.PsiJavaFile") }.isSuccess
 

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -126,5 +126,5 @@ fun PsiReference.safeResolve(): PsiElement? = try {
 
 fun PsiElement.isInKotlinFile(): Boolean {
   val containingKtFile = containingKtFile() ?: return false
-  return InjectedLanguageManager.getInstance(project).isInjectedFragment(containingKtFile)
+  return !InjectedLanguageManager.getInstance(project).isInjectedFragment(containingKtFile)
 }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -1,11 +1,11 @@
 package com.apollographql.ijplugin.util
 
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.diagnostic.ControlFlowException
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.util.PsiTreeUtil
-import org.jetbrains.kotlin.idea.refactoring.isInjectedFragment
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.name.FqName
@@ -126,5 +126,5 @@ fun PsiReference.safeResolve(): PsiElement? = try {
 
 fun PsiElement.isInKotlinFile(): Boolean {
   val containingKtFile = containingKtFile() ?: return false
-  return !containingKtFile.isInjectedFragment
+  return InjectedLanguageManager.getInstance(project).isInjectedFragment(containingKtFile)
 }


### PR DESCRIPTION
<!-- GRAPHOS-318 -->
APIs we use to communicate with a device in the Normalized Cache viewer (notably `AdbShellCommandsUtil.create(Device)` disappeared in AS Quail, breaking the "Pull from device" feature.

This isn't the first time this has happened.

In this PR, we try to avoid APIs in `com.android.tools.idea.adb` and try to favor the ones in `com.android.adblib` which I think/hope are more stable.

For now this fixes the issue in Quail, and I also verified it still works in Panda.