### PR TITLE
Migrate Develocity publishing to the OSS Community Develocity Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Version](https://img.shields.io/jetbrains/plugin/v/20645.svg)](https://plugins.jetbrains.com/plugin/20645)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/20645.svg)](https://plugins.jetbrains.com/plugin/20645)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=apollo-intellij-plugin)
 
 <!-- Plugin description -->
 

--- a/gradle/ge.gradle
+++ b/gradle/ge.gradle
@@ -1,7 +1,8 @@
 def isCI = System.getenv("CI") != null
 
 develocity {
-  server = "https://ge.apollographql.com"
+  server = "https://community.develocity.cloud"
+  projectId = "apollo"
   allowUntrustedServer = false
 
   buildScan {


### PR DESCRIPTION
# Migrate Develocity publishing to the OSS Community Develocity Instance

This migrates the project's Build Scan® and Build Cache publishing from the dedicated `ge.apollographql.com` instance to the shared, Gradle-managed **OSS Community Develocity Instance** at <https://community.develocity.cloud> (project `apollo`).

## Changes
- `gradle/ge.gradle` — point `server` at `https://community.develocity.cloud` and set `projectId = "apollo"`.
- `README.md` — update the "Revved up by Develocity" badge to link to the community instance.

## Action required: update the CI access-key secret
CI already passes `DEVELOCITY_ACCESS_KEY`; only its **value** needs to change to the new host.

1. Repo **Settings → Secrets and variables → Actions**
2. Update (or add) the `DEVELOCITY_ACCESS_KEY` secret to:

   ```
   community.develocity.cloud=<the apollo-ci access key shared with you>
   ```

   The `community.develocity.cloud=` prefix is required — without the host, the key is silently ignored.

## Local builds (optional)
Contributors can provision a personal key for the new instance:

```
./gradlew provisionDevelocityAccessKey
```

## Note on this PR's own CI run
This PR is from a fork, so its CI run can't read the repository secret and won't publish a scan. After merge, CI on this repository will publish to <https://community.develocity.cloud>.
