### PR TITLE
Fix indexing for external Apollo schemas

### DIFF
--- a/jsgraphql/src/main/java/com/intellij/lang/jsgraphql/ide/config/model/GraphQLProjectConfig.kt
+++ b/jsgraphql/src/main/java/com/intellij/lang/jsgraphql/ide/config/model/GraphQLProjectConfig.kt
@@ -83,7 +83,7 @@ class GraphQLProjectConfig(
       .filterNot { it.isRemote }
       .mapNotNull { it.outputPath }
       .map(FileUtil::toCanonicalPath)
-      .filter { FileUtil.isAncestor(dir.path, it, false) == false }
+      .filterNot { FileUtil.isAncestor(dir.path, it, false) }
       .distinct()
       .toList()
   }

--- a/jsgraphql/src/main/java/com/intellij/lang/jsgraphql/ide/config/model/GraphQLProjectConfig.kt
+++ b/jsgraphql/src/main/java/com/intellij/lang/jsgraphql/ide/config/model/GraphQLProjectConfig.kt
@@ -80,9 +80,11 @@ class GraphQLProjectConfig(
 
   private val outOfScopePaths: List<String> by lazy {
     schema.asSequence()
-      .mapNotNull { it.filePath }
-      .filter { it.startsWith("..") }
-      .map { FileUtil.toCanonicalPath(FileUtil.join(dir.path, FileUtil.toSystemIndependentName(it))) }
+      .filterNot { it.isRemote }
+      .mapNotNull { it.outputPath }
+      .map(FileUtil::toCanonicalPath)
+      .filter { FileUtil.isAncestor(dir.path, it, false) == false }
+      .distinct()
       .toList()
   }
 

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinProjectModelService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinProjectModelService.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.launch
 import org.gradle.tooling.CancellationTokenSource
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.model.GradleProject
+import org.jetbrains.annotations.TestOnly
 import java.io.File
 
 const val GENERATE_PROJECT_MODEL_TASK_NAME = "generateApolloProjectModel"
@@ -544,6 +545,13 @@ class ApolloKotlinProjectModelService(
 
   fun getApolloKotlinServices(): List<ApolloKotlinService> {
     return apolloKotlinServices.values.toList()
+  }
+
+  @TestOnly
+  internal fun replaceApolloKotlinServicesForTest(apolloKotlinServices: List<ApolloKotlinService>) {
+    this.apolloKotlinServices = apolloKotlinServices.associateBy { it.id }
+    project.projectSettingsState.apolloKotlinServices = apolloKotlinServices
+    project.messageBus.syncPublisher(ApolloKotlinServiceListener.TOPIC).apolloKotlinServicesAvailable()
   }
 
   fun getApolloKotlinService(id: ApolloKotlinService.Id): ApolloKotlinService? {

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinProjectModelService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinProjectModelService.kt
@@ -549,9 +549,10 @@ class ApolloKotlinProjectModelService(
 
   @TestOnly
   internal fun replaceApolloKotlinServicesForTest(apolloKotlinServices: List<ApolloKotlinService>) {
-    this.apolloKotlinServices = apolloKotlinServices.associateBy { it.id }
-    project.projectSettingsState.apolloKotlinServices = apolloKotlinServices
-    project.messageBus.syncPublisher(ApolloKotlinServiceListener.TOPIC).apolloKotlinServicesAvailable()
+    saveApolloKotlinServices(
+        apolloKotlinServices,
+        project.projectSettingsState.apolloTasksDependencies.toSet(),
+    )
   }
 
   fun getApolloKotlinService(id: ApolloKotlinService.Id): ApolloKotlinService? {

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
@@ -1,5 +1,6 @@
 package com.apollographql.ijplugin.graphql
 
+import com.intellij.openapi.components.serviceIfCreated
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
 import com.intellij.openapi.roots.SyntheticLibrary
@@ -26,7 +27,7 @@ class ApolloExternalSchemaLibraryRootsProvider : AdditionalLibraryRootsProvider(
   }
 
   private fun snapshot(project: Project): ApolloExternalSchemaSnapshot {
-    return project.getServiceIfCreated(GraphQLConfigService::class.java)?.externalSchemaSnapshot
+    return project.serviceIfCreated<GraphQLConfigService>()?.externalSchemaSnapshot
         ?: ApolloExternalSchemaSnapshot.EMPTY
   }
 

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
@@ -1,6 +1,6 @@
 package com.apollographql.ijplugin.graphql
 
-import com.intellij.openapi.components.serviceIfCreated
+import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
 import com.intellij.openapi.roots.SyntheticLibrary
@@ -27,7 +27,7 @@ class ApolloExternalSchemaLibraryRootsProvider : AdditionalLibraryRootsProvider(
   }
 
   private fun snapshot(project: Project): ApolloExternalSchemaSnapshot {
-    return project.serviceIfCreated<GraphQLConfigService>()?.externalSchemaSnapshot
+    return project.serviceOrNull<GraphQLConfigService>()?.externalSchemaSnapshot
         ?: ApolloExternalSchemaSnapshot.EMPTY
   }
 

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
@@ -1,0 +1,78 @@
+package com.apollographql.ijplugin.graphql
+
+import com.apollographql.ijplugin.gradle.apolloKotlinProjectModelService
+import com.apollographql.ijplugin.settings.projectSettingsState
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.roots.SyntheticLibrary
+import com.intellij.openapi.util.RecursionManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import java.io.File
+import java.util.Collections
+
+class ApolloExternalSchemaLibraryRootsProvider : AdditionalLibraryRootsProvider() {
+  override fun getAdditionalProjectLibraries(project: Project): Collection<SyntheticLibrary> {
+    val roots = externalSchemaRoots(project)
+    if (roots.isEmpty()) return emptyList()
+
+    return listOf(
+        SyntheticLibrary.newImmutableLibrary(
+            COMPARISON_ID,
+            roots.toList(),
+            emptyList(),
+            emptySet(),
+            null,
+        )
+    )
+  }
+
+  override fun getRootsToWatch(project: Project): Collection<VirtualFile> {
+    if (!project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return emptyList()
+
+    val parentPaths = configuredSchemaPaths(project)
+        .mapNotNull { File(it).parentFile?.absolutePath }
+        .distinct()
+
+    return runReadAction {
+      val projectFileIndex = ProjectFileIndex.getInstance(project)
+      parentPaths
+          .mapNotNull { LocalFileSystem.getInstance().findFileByPath(FileUtil.toSystemIndependentName(it)) }
+          .filter { it.isValid && it.isDirectory && !projectFileIndex.isInContent(it) }
+          .sortedBy { it.path }
+    }
+  }
+
+  companion object {
+    private const val COMPARISON_ID = "apollo-external-graphql-schemas"
+
+    // ProjectFileIndex refreshes additional-library contributors, which can call this provider recursively.
+    private val fileIndexRecursionGuard =
+      RecursionManager.createGuard<Project>(ApolloExternalSchemaLibraryRootsProvider::class.java.name)
+
+    internal fun externalSchemaRoots(project: Project): Set<VirtualFile> {
+      if (!project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return emptySet()
+
+      return fileIndexRecursionGuard.computePreventingRecursion<Set<VirtualFile>, RuntimeException>(project, false) {
+        val schemaPaths = configuredSchemaPaths(project)
+        runReadAction {
+          val projectFileIndex = ProjectFileIndex.getInstance(project)
+          val roots = schemaPaths
+              .mapNotNull { LocalFileSystem.getInstance().findFileByPath(it) }
+              .filter { it.isValid && !it.isDirectory && !projectFileIndex.isInContent(it) }
+              .sortedBy { it.path }
+          Collections.unmodifiableSet(LinkedHashSet(roots))
+        }
+      } ?: emptySet()
+    }
+  }
+}
+
+private fun configuredSchemaPaths(project: Project): List<String> {
+  return project.apolloKotlinProjectModelService.getApolloKotlinServices()
+      .flatMap { it.allSchemaPaths }
+      .distinct()
+}

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProvider.kt
@@ -1,28 +1,19 @@
 package com.apollographql.ijplugin.graphql
 
-import com.apollographql.ijplugin.gradle.apolloKotlinProjectModelService
-import com.apollographql.ijplugin.settings.projectSettingsState
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
-import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.SyntheticLibrary
-import com.intellij.openapi.util.RecursionManager
-import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import java.io.File
-import java.util.Collections
 
 class ApolloExternalSchemaLibraryRootsProvider : AdditionalLibraryRootsProvider() {
   override fun getAdditionalProjectLibraries(project: Project): Collection<SyntheticLibrary> {
-    val roots = externalSchemaRoots(project)
+    val roots = snapshot(project).externalSchemaRoots.filter { it.isValid }
     if (roots.isEmpty()) return emptyList()
 
     return listOf(
         SyntheticLibrary.newImmutableLibrary(
             COMPARISON_ID,
-            roots.toList(),
+            roots,
             emptyList(),
             emptySet(),
             null,
@@ -31,48 +22,15 @@ class ApolloExternalSchemaLibraryRootsProvider : AdditionalLibraryRootsProvider(
   }
 
   override fun getRootsToWatch(project: Project): Collection<VirtualFile> {
-    if (!project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return emptyList()
+    return snapshot(project).watchRoots.filter { it.isValid }
+  }
 
-    val parentPaths = configuredSchemaPaths(project)
-        .mapNotNull { File(it).parentFile?.absolutePath }
-        .distinct()
-
-    return runReadAction {
-      val projectFileIndex = ProjectFileIndex.getInstance(project)
-      parentPaths
-          .mapNotNull { LocalFileSystem.getInstance().findFileByPath(FileUtil.toSystemIndependentName(it)) }
-          .filter { it.isValid && it.isDirectory && !projectFileIndex.isInContent(it) }
-          .sortedBy { it.path }
-    }
+  private fun snapshot(project: Project): ApolloExternalSchemaSnapshot {
+    return project.getServiceIfCreated(GraphQLConfigService::class.java)?.externalSchemaSnapshot
+        ?: ApolloExternalSchemaSnapshot.EMPTY
   }
 
   companion object {
     private const val COMPARISON_ID = "apollo-external-graphql-schemas"
-
-    // ProjectFileIndex refreshes additional-library contributors, which can call this provider recursively.
-    private val fileIndexRecursionGuard =
-      RecursionManager.createGuard<Project>(ApolloExternalSchemaLibraryRootsProvider::class.java.name)
-
-    internal fun externalSchemaRoots(project: Project): Set<VirtualFile> {
-      if (!project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return emptySet()
-
-      return fileIndexRecursionGuard.computePreventingRecursion<Set<VirtualFile>, RuntimeException>(project, false) {
-        val schemaPaths = configuredSchemaPaths(project)
-        runReadAction {
-          val projectFileIndex = ProjectFileIndex.getInstance(project)
-          val roots = schemaPaths
-              .mapNotNull { LocalFileSystem.getInstance().findFileByPath(it) }
-              .filter { it.isValid && !it.isDirectory && !projectFileIndex.isInContent(it) }
-              .sortedBy { it.path }
-          Collections.unmodifiableSet(LinkedHashSet(roots))
-        }
-      } ?: emptySet()
-    }
   }
-}
-
-private fun configuredSchemaPaths(project: Project): List<String> {
-  return project.apolloKotlinProjectModelService.getApolloKotlinServices()
-      .flatMap { it.allSchemaPaths }
-      .distinct()
 }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloGraphQLConfigContributor.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloGraphQLConfigContributor.kt
@@ -13,8 +13,8 @@ import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawSchemaPointer
 import com.intellij.lang.jsgraphql.ide.config.model.GraphQLConfig
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.vfs.VfsUtilCore
-import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFile
 import java.io.File
 
 class ApolloGraphQLConfigContributor : GraphQLConfigContributor {
@@ -33,16 +33,16 @@ class ApolloGraphQLConfigContributor : GraphQLConfigContributor {
             file = null,
             rawData = GraphQLRawConfig(
                 projects = project.apolloKotlinProjectModelService.getApolloKotlinServices().associate { apolloKotlinService ->
-                  apolloKotlinService.id.toString() to apolloKotlinService.toGraphQLRawProjectConfig(project)
+                  apolloKotlinService.id.toString() to apolloKotlinService.toGraphQLRawProjectConfig(projectDir)
                 }
             )
         )
     )
   }
 
-  private fun ApolloKotlinService.toGraphQLRawProjectConfig(project: Project) = GraphQLRawProjectConfig(
-      schema = allSchemaPaths.map { GraphQLRawSchemaPointer(it.toProjectRelativePath(project)) },
-      include = allOperationPaths.map { "${it.toProjectRelativePath(project)}/**/*.graphql" },
+  private fun ApolloKotlinService.toGraphQLRawProjectConfig(projectDir: VirtualFile) = GraphQLRawProjectConfig(
+      schema = allSchemaPaths.map { GraphQLRawSchemaPointer(it.toGraphQLConfigPath(projectDir)) },
+      include = allOperationPaths.map { "${it.toGraphQLConfigPath(projectDir)}/**/*.graphql" },
       extensions = mapOf(EXTENSION_APOLLO_KOTLIN_SERVICE_ID to this.id.toString()) +
           (endpointUrl?.let {
             mapOf(
@@ -63,8 +63,7 @@ class ApolloGraphQLConfigContributor : GraphQLConfigContributor {
   }
 }
 
-private fun String.toProjectRelativePath(project: Project): String {
-  val projectDir = project.guessProjectDir() ?: return ""
-  val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(File(this).toPath()) ?: return ""
-  return VfsUtilCore.getRelativeLocation(virtualFile, projectDir) ?: ""
+internal fun String.toGraphQLConfigPath(projectDir: VirtualFile): String {
+  val relativePath = FileUtil.getRelativePath(File(projectDir.path), File(this))
+  return FileUtil.toSystemIndependentName(relativePath ?: File(this).absolutePath)
 }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
@@ -43,6 +43,9 @@ internal data class ApolloExternalSchemaSnapshot(
   }
 }
 
+private fun String.toParentSystemIndependentPath(): String? =
+  File(this).parentFile?.absolutePath?.let(FileUtil::toSystemIndependentName)
+
 /**
  *  Listens to availability of Tooling model, and notifies the GraphQL plugin.
  */
@@ -181,13 +184,11 @@ class GraphQLConfigService(
           .filter { it.isValid && !it.isDirectory && !projectFileIndex.isInContent(it) }
           .sortedBy { it.path }
       val watchRootPaths = configuredSchemaPaths
-          .mapNotNull { File(it).parentFile?.absolutePath }
-          .map(FileUtil::toSystemIndependentName)
+          .mapNotNull { it.toParentSystemIndependentPath() }
           .distinct()
           .filter { path ->
-            val closestExistingFile = generateSequence(path) {
-              File(it).parentFile?.absolutePath?.let(FileUtil::toSystemIndependentName)
-            }.mapNotNull(localFileSystem::findFileByPath)
+            val closestExistingFile = generateSequence(path) { it.toParentSystemIndependentPath() }
+                .mapNotNull(localFileSystem::findFileByPath)
                 .firstOrNull { it.isValid }
             closestExistingFile == null || !projectFileIndex.isInContent(closestExistingFile)
           }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
@@ -1,12 +1,19 @@
 package com.apollographql.ijplugin.graphql
 
 import com.apollographql.ijplugin.gradle.ApolloKotlinServiceListener
+import com.apollographql.ijplugin.settings.ProjectSettingsListener
+import com.apollographql.ijplugin.settings.ProjectSettingsState
+import com.apollographql.ijplugin.settings.projectSettingsState
 import com.apollographql.ijplugin.util.logd
 import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigProvider
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.AdditionalLibraryRootsListener
+import com.intellij.openapi.vfs.VirtualFile
 
 /**
  *  Listens to availability of Tooling model, and notifies the GraphQL plugin.
@@ -15,14 +22,53 @@ import com.intellij.openapi.project.Project
 class GraphQLConfigService(
     private val project: Project,
 ) : Disposable {
+  private var publishedExternalSchemaRoots: Set<VirtualFile> = emptySet()
+  private var contributeConfigurationToGraphqlPlugin =
+    project.projectSettingsState.contributeConfigurationToGraphqlPlugin
+
   init {
     logd("project=${project.name}")
     project.messageBus.connect(this).subscribe(ApolloKotlinServiceListener.TOPIC, object : ApolloKotlinServiceListener {
       override fun apolloKotlinServicesAvailable() {
-        logd("Calling scheduleConfigurationReload")
-        project.service<GraphQLConfigProvider>().scheduleConfigurationReload()
+        this@GraphQLConfigService.apolloKotlinServicesAvailable()
       }
     })
+    project.messageBus.connect(this).subscribe(ProjectSettingsListener.TOPIC, object : ProjectSettingsListener {
+      override fun settingsChanged(projectSettingsState: ProjectSettingsState) {
+        val newValue = projectSettingsState.contributeConfigurationToGraphqlPlugin
+        if (newValue == contributeConfigurationToGraphqlPlugin) return
+
+        contributeConfigurationToGraphqlPlugin = newValue
+        apolloKotlinServicesAvailable()
+      }
+    })
+  }
+
+  private fun apolloKotlinServicesAvailable() {
+    val newRoots = ApolloExternalSchemaLibraryRootsProvider.externalSchemaRoots(project)
+    ApplicationManager.getApplication().invokeLater {
+      if (project.isDisposed) return@invokeLater
+
+      val oldRoots = publishedExternalSchemaRoots
+      if (newRoots != oldRoots) {
+        WriteAction.run<Throwable> {
+          AdditionalLibraryRootsListener.fireAdditionalLibraryChanged(
+              project,
+              null,
+              oldRoots,
+              newRoots,
+              "Apollo external GraphQL schemas",
+          )
+          publishedExternalSchemaRoots = newRoots
+        }
+      }
+      scheduleConfigurationReload()
+    }
+  }
+
+  private fun scheduleConfigurationReload() {
+    logd("Calling scheduleConfigurationReload")
+    project.service<GraphQLConfigProvider>().scheduleConfigurationReload()
   }
 
   override fun dispose() {

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.graphql
 
 import com.apollographql.ijplugin.gradle.ApolloKotlinServiceListener
+import com.apollographql.ijplugin.gradle.apolloKotlinProjectModelService
 import com.apollographql.ijplugin.settings.ProjectSettingsListener
 import com.apollographql.ijplugin.settings.ProjectSettingsState
 import com.apollographql.ijplugin.settings.projectSettingsState
@@ -9,11 +10,38 @@ import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigProvider
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsListener
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileCopyEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
+import com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent
+import java.io.File
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
+import org.jetbrains.annotations.TestOnly
+
+internal data class ApolloExternalSchemaSnapshot(
+    val configuredSchemaPaths: List<String>,
+    val externalSchemaRoots: Set<VirtualFile>,
+    val watchRootPaths: List<String>,
+    val watchRoots: List<VirtualFile>,
+) {
+  companion object {
+    val EMPTY = ApolloExternalSchemaSnapshot(emptyList(), emptySet(), emptyList(), emptyList())
+  }
+}
 
 /**
  *  Listens to availability of Tooling model, and notifies the GraphQL plugin.
@@ -22,9 +50,17 @@ import com.intellij.openapi.vfs.VirtualFile
 class GraphQLConfigService(
     private val project: Project,
 ) : Disposable {
-  private var publishedExternalSchemaRoots: Set<VirtualFile> = emptySet()
+  @Volatile
+  internal var externalSchemaSnapshot: ApolloExternalSchemaSnapshot = ApolloExternalSchemaSnapshot.EMPTY
+    private set
   private var contributeConfigurationToGraphqlPlugin =
     project.projectSettingsState.contributeConfigurationToGraphqlPlugin
+  private val externalSchemaSnapshotRefreshScheduled = AtomicBoolean()
+  private val configuredSchemaPathsRefreshRequested = AtomicBoolean()
+  private val configurationReloadRequested = AtomicBoolean()
+  private val watchRequestsLock = Any()
+  private var watchRequests: Set<LocalFileSystem.WatchRequest> = emptySet()
+  private var disposed = false
 
   init {
     logd("project=${project.name}")
@@ -42,27 +78,173 @@ class GraphQLConfigService(
         apolloKotlinServicesAvailable()
       }
     })
+    project.messageBus.connect(this).subscribe(VirtualFileManager.VFS_CHANGES, object : BulkFileListener {
+      override fun after(events: MutableList<out VFileEvent>) {
+        if (eventsAffectConfiguredSchemas(events, externalSchemaSnapshot.configuredSchemaPaths)) {
+          scheduleExternalSchemaSnapshotRefresh(
+              reloadConfiguration = false,
+              refreshConfiguredSchemaPaths = false,
+          )
+        }
+      }
+    })
   }
 
   private fun apolloKotlinServicesAvailable() {
-    val newRoots = ApolloExternalSchemaLibraryRootsProvider.externalSchemaRoots(project)
+    scheduleExternalSchemaSnapshotRefresh(
+        reloadConfiguration = true,
+        refreshConfiguredSchemaPaths = true,
+    )
+  }
+
+  private fun scheduleExternalSchemaSnapshotRefresh(
+      reloadConfiguration: Boolean,
+      refreshConfiguredSchemaPaths: Boolean,
+  ) {
+    if (reloadConfiguration) {
+      configurationReloadRequested.set(true)
+    }
+    if (refreshConfiguredSchemaPaths) {
+      configuredSchemaPathsRefreshRequested.set(true)
+    }
+    if (!externalSchemaSnapshotRefreshScheduled.compareAndSet(false, true)) return
+
     ApplicationManager.getApplication().invokeLater {
+      externalSchemaSnapshotRefreshScheduled.set(false)
       if (project.isDisposed) return@invokeLater
 
-      val oldRoots = publishedExternalSchemaRoots
-      if (newRoots != oldRoots) {
+      refreshExternalSchemaSnapshot(
+          reloadConfiguration = configurationReloadRequested.getAndSet(false),
+          refreshConfiguredSchemaPaths = configuredSchemaPathsRefreshRequested.getAndSet(false),
+      )
+    }
+  }
+
+  private fun refreshExternalSchemaSnapshot(
+      reloadConfiguration: Boolean,
+      refreshConfiguredSchemaPaths: Boolean,
+  ) {
+    val oldSnapshot = externalSchemaSnapshot
+    val configuredSchemaPaths = if (refreshConfiguredSchemaPaths) {
+      computeConfiguredSchemaPaths()
+    } else {
+      oldSnapshot.configuredSchemaPaths
+    }
+    val newSnapshot = computeExternalSchemaSnapshot(configuredSchemaPaths)
+    val configuredSchemaPathsChanged = newSnapshot.configuredSchemaPaths != oldSnapshot.configuredSchemaPaths
+    val rootsChanged = newSnapshot.externalSchemaRoots != oldSnapshot.externalSchemaRoots
+    val watchRootPathsChanged = newSnapshot.watchRootPaths != oldSnapshot.watchRootPaths
+    val watchRootsChanged = newSnapshot.watchRoots != oldSnapshot.watchRoots
+    val snapshotChanged = configuredSchemaPathsChanged || rootsChanged || watchRootPathsChanged || watchRootsChanged
+
+    if (snapshotChanged) {
+      externalSchemaSnapshot = newSnapshot
+      if (watchRootPathsChanged) {
+        replaceWatchRequests(newSnapshot.watchRootPaths)
+      }
+      if (rootsChanged || watchRootsChanged) {
         WriteAction.run<Throwable> {
           AdditionalLibraryRootsListener.fireAdditionalLibraryChanged(
               project,
               null,
-              oldRoots,
-              newRoots,
+              oldSnapshot.externalSchemaRoots,
+              newSnapshot.externalSchemaRoots,
               "Apollo external GraphQL schemas",
           )
-          publishedExternalSchemaRoots = newRoots
         }
       }
+    }
+    if (reloadConfiguration || snapshotChanged) {
       scheduleConfigurationReload()
+    }
+  }
+
+  private fun computeConfiguredSchemaPaths(): List<String> {
+    if (!project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return emptyList()
+
+    val paths = project.apolloKotlinProjectModelService.getApolloKotlinServices()
+        .flatMap { it.allSchemaPaths }
+        .map { FileUtil.toSystemIndependentName(File(it).absolutePath) }
+        .distinct()
+        .sorted()
+    return Collections.unmodifiableList(paths)
+  }
+
+  private fun computeExternalSchemaSnapshot(configuredSchemaPaths: List<String>): ApolloExternalSchemaSnapshot {
+    if (configuredSchemaPaths.isEmpty()) return ApolloExternalSchemaSnapshot.EMPTY
+
+    return runReadAction {
+      val projectFileIndex = ProjectFileIndex.getInstance(project)
+      val localFileSystem = LocalFileSystem.getInstance()
+      val externalRoots = configuredSchemaPaths
+          .mapNotNull(localFileSystem::findFileByPath)
+          .filter { it.isValid && !it.isDirectory && !projectFileIndex.isInContent(it) }
+          .sortedBy { it.path }
+      val watchRootPaths = configuredSchemaPaths
+          .mapNotNull { File(it).parentFile?.absolutePath }
+          .map(FileUtil::toSystemIndependentName)
+          .distinct()
+          .filter { path ->
+            val closestExistingFile = generateSequence(path) {
+              File(it).parentFile?.absolutePath?.let(FileUtil::toSystemIndependentName)
+            }.mapNotNull(localFileSystem::findFileByPath)
+                .firstOrNull { it.isValid }
+            closestExistingFile == null || !projectFileIndex.isInContent(closestExistingFile)
+          }
+          .sorted()
+      val watchRoots = watchRootPaths
+          .mapNotNull(localFileSystem::findFileByPath)
+          .filter { it.isValid && it.isDirectory }
+          .sortedBy { it.path }
+      ApolloExternalSchemaSnapshot(
+          configuredSchemaPaths = configuredSchemaPaths,
+          externalSchemaRoots = Collections.unmodifiableSet(LinkedHashSet(externalRoots)),
+          watchRootPaths = Collections.unmodifiableList(watchRootPaths),
+          watchRoots = Collections.unmodifiableList(watchRoots),
+      )
+    }
+  }
+
+  private fun replaceWatchRequests(watchRootPaths: List<String>) {
+    synchronized(watchRequestsLock) {
+      if (disposed) return
+
+      watchRequests = LocalFileSystem.getInstance().replaceWatchedRoots(
+          watchRequests,
+          watchRootPaths,
+          null,
+      )
+    }
+  }
+
+  @TestOnly
+  internal fun registeredWatchRootPaths(): Set<String> {
+    return synchronized(watchRequestsLock) {
+      watchRequests.mapTo(linkedSetOf()) { it.rootPath }
+    }
+  }
+
+  private fun eventsAffectConfiguredSchemas(
+      events: List<VFileEvent>,
+      configuredSchemaPaths: List<String>,
+  ): Boolean {
+    if (configuredSchemaPaths.isEmpty()) return false
+
+    return events.asSequence()
+        .flatMap { it.topologyChangePaths().asSequence() }
+        .map(FileUtil::toSystemIndependentName)
+        .any { changedPath -> configuredSchemaPaths.any { FileUtil.isAncestor(changedPath, it, false) } }
+  }
+
+  private fun VFileEvent.topologyChangePaths(): List<String> {
+    return when (this) {
+      is VFileCreateEvent, is VFileCopyEvent, is VFileDeleteEvent -> listOf(path)
+      is VFileMoveEvent -> listOf(oldPath, newPath)
+      is VFilePropertyChangeEvent -> {
+        if (propertyName == VirtualFile.PROP_NAME) listOf(oldPath, newPath) else emptyList()
+      }
+
+      else -> emptyList()
     }
   }
 
@@ -73,5 +255,10 @@ class GraphQLConfigService(
 
   override fun dispose() {
     logd("project=${project.name}")
+    synchronized(watchRequestsLock) {
+      disposed = true
+      LocalFileSystem.getInstance().removeWatchedRoots(watchRequests)
+      watchRequests = emptySet()
+    }
   }
 }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLConfigService.kt
@@ -8,8 +8,8 @@ import com.apollographql.ijplugin.settings.projectSettingsState
 import com.apollographql.ijplugin.util.logd
 import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigProvider
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -28,7 +28,6 @@ import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
 import com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent
 import java.io.File
-import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
 import org.jetbrains.annotations.TestOnly
 
@@ -112,7 +111,7 @@ class GraphQLConfigService(
     }
     if (!externalSchemaSnapshotRefreshScheduled.compareAndSet(false, true)) return
 
-    ApplicationManager.getApplication().invokeLater {
+    invokeLater {
       externalSchemaSnapshotRefreshScheduled.set(false)
       if (project.isDisposed) return@invokeLater
 
@@ -165,12 +164,11 @@ class GraphQLConfigService(
   private fun computeConfiguredSchemaPaths(): List<String> {
     if (!project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return emptyList()
 
-    val paths = project.apolloKotlinProjectModelService.getApolloKotlinServices()
+    return project.apolloKotlinProjectModelService.getApolloKotlinServices()
         .flatMap { it.allSchemaPaths }
         .map { FileUtil.toSystemIndependentName(File(it).absolutePath) }
         .distinct()
         .sorted()
-    return Collections.unmodifiableList(paths)
   }
 
   private fun computeExternalSchemaSnapshot(configuredSchemaPaths: List<String>): ApolloExternalSchemaSnapshot {
@@ -199,9 +197,9 @@ class GraphQLConfigService(
           .sortedBy { it.path }
       ApolloExternalSchemaSnapshot(
           configuredSchemaPaths = configuredSchemaPaths,
-          externalSchemaRoots = Collections.unmodifiableSet(LinkedHashSet(externalRoots)),
-          watchRootPaths = Collections.unmodifiableList(watchRootPaths),
-          watchRoots = Collections.unmodifiableList(watchRoots),
+          externalSchemaRoots = externalRoots.toSet(),
+          watchRootPaths = watchRootPaths,
+          watchRoots = watchRoots,
       )
     }
   }

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Files.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Files.kt
@@ -2,7 +2,6 @@ package com.apollographql.ijplugin.util
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.GeneratedSourcesFilter
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiFile
@@ -19,11 +18,7 @@ fun Project.findPsiFilesByName(fileName: String, searchScope: GlobalSearchScope)
 }
 
 fun Project.findPsiFileByPath(path: String): PsiFile? {
-  val nioPath = Path.of(path)
-  val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(nioPath)
-      ?: FilenameIndex.getVirtualFilesByName(nioPath.fileName.toString(), GlobalSearchScope.allScope(this))
-          .firstOrNull { FileUtil.pathsEqual(it.path, path) }
-  return virtualFile?.let { PsiManager.getInstance(this).findFile(it) }
+  return VirtualFileManager.getInstance().findFileByNioPath(Path.of(path))?.let { PsiManager.getInstance(this).findFile(it) }
 }
 
 fun File.toVirtualFile(): VirtualFile? {

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Files.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/Files.kt
@@ -2,6 +2,7 @@ package com.apollographql.ijplugin.util
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.GeneratedSourcesFilter
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiFile
@@ -18,7 +19,11 @@ fun Project.findPsiFilesByName(fileName: String, searchScope: GlobalSearchScope)
 }
 
 fun Project.findPsiFileByPath(path: String): PsiFile? {
-  return VirtualFileManager.getInstance().findFileByNioPath(Path.of(path))?.let { PsiManager.getInstance(this).findFile(it) }
+  val nioPath = Path.of(path)
+  val virtualFile = VirtualFileManager.getInstance().findFileByNioPath(nioPath)
+      ?: FilenameIndex.getVirtualFilesByName(nioPath.fileName.toString(), GlobalSearchScope.allScope(this))
+          .firstOrNull { FileUtil.pathsEqual(it.path, path) }
+  return virtualFile?.let { PsiManager.getInstance(this).findFile(it) }
 }
 
 fun File.toVirtualFile(): VirtualFile? {

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/GraphQL.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/GraphQL.kt
@@ -19,6 +19,7 @@ import com.intellij.lang.jsgraphql.psi.GraphQLType
 import com.intellij.lang.jsgraphql.psi.GraphQLTypeName
 import com.intellij.lang.jsgraphql.psi.GraphQLValue
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
 import com.intellij.psi.util.parentOfType
 import com.intellij.psi.util.parentOfTypes
 
@@ -89,9 +90,14 @@ private fun matchingFieldCoordinates(
 fun GraphQLElement.schemaFiles(): List<GraphQLFile> {
   val containingFile = containingFile ?: return emptyList()
   val projectConfig = GraphQLConfigProvider.getInstance(project).resolveProjectConfig(containingFile) ?: return emptyList()
-  return projectConfig.schema.mapNotNull { schema ->
-    schema.outputPath?.let { project.findPsiFileByPath(it) } as? GraphQLFile
-  }
+  return projectConfig.schema.asSequence()
+      .filterNot { it.isRemote }
+      .mapNotNull { schema ->
+        schema.outputPath
+            ?.let(schema.dir.fileSystem::findFileByPath)
+            ?.let(PsiManager.getInstance(project)::findFile) as? GraphQLFile
+      }
+      .toList()
 }
 
 /**

--- a/plugin/src/main/kotlin/com/apollographql/ijplugin/util/GraphQL.kt
+++ b/plugin/src/main/kotlin/com/apollographql/ijplugin/util/GraphQL.kt
@@ -90,7 +90,7 @@ fun GraphQLElement.schemaFiles(): List<GraphQLFile> {
   val containingFile = containingFile ?: return emptyList()
   val projectConfig = GraphQLConfigProvider.getInstance(project).resolveProjectConfig(containingFile) ?: return emptyList()
   return projectConfig.schema.mapNotNull { schema ->
-    schema.filePath?.let { path -> project.findPsiFileByUrl(schema.dir.url + "/" + path) } as? GraphQLFile
+    schema.outputPath?.let { project.findPsiFileByPath(it) } as? GraphQLFile
   }
 }
 

--- a/plugin/src/main/resources/META-INF/com.apollographql.ijplugin-gradle.xml
+++ b/plugin/src/main/resources/META-INF/com.apollographql.ijplugin-gradle.xml
@@ -5,5 +5,7 @@
     <!-- Listen to Gradle sync -->
     <externalSystemTaskNotificationListener implementation="com.apollographql.ijplugin.gradle.GradleListener" />
 
+    <additionalLibraryRootsProvider implementation="com.apollographql.ijplugin.graphql.ApolloExternalSchemaLibraryRootsProvider" />
+
   </extensions>
 </idea-plugin>

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProviderTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProviderTest.kt
@@ -1,13 +1,20 @@
 package com.apollographql.ijplugin.graphql
 
+import com.apollographql.ijplugin.gradle.ApolloKotlinProjectModelService
 import com.apollographql.ijplugin.gradle.ApolloKotlinService
 import com.apollographql.ijplugin.gradle.apolloKotlinProjectModelService
 import com.apollographql.ijplugin.settings.projectSettingsState
+import com.intellij.mock.MockProject
 import com.intellij.openapi.components.service
 import com.intellij.openapi.roots.AdditionalLibraryRootsListener
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.IndexingTestUtil
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.ui.UIUtil
 import org.junit.Test
@@ -37,32 +44,188 @@ class ApolloExternalSchemaLibraryRootsProviderTest : BasePlatformTestCase() {
   }
 
   @Test
+  fun rootsToWatchDoesNotCreateApolloModelService() {
+    val uninitializedProject = MockProject(null, testRootDisposable)
+    assertNull(uninitializedProject.getServiceIfCreated(ApolloKotlinProjectModelService::class.java))
+
+    assertEmpty(ApolloExternalSchemaLibraryRootsProvider().getRootsToWatch(uninitializedProject))
+
+    assertNull(uninitializedProject.getServiceIfCreated(ApolloKotlinProjectModelService::class.java))
+  }
+
+  @Test
   fun externalSchemaFilesBecomeSyntheticLibrarySourceRoots() {
+    project.service<GraphQLConfigService>()
     val internalSchema = myFixture.addFileToProject("graphql/internal.graphqls", "type Query").virtualFile
-    val externalSchema = createExternalFile("schema.graphqls")
-    setSchemaPaths(externalSchema.path, internalSchema.path, externalSchema.path)
+    val firstExternalSchema = createExternalFile("z-schema.graphqls")
+    val secondExternalSchema = createExternalFile("a-schema.graphqls")
+    setSchemaPaths(firstExternalSchema.path, internalSchema.path, secondExternalSchema.path, firstExternalSchema.path)
+    UIUtil.dispatchAllInvocationEvents()
 
-    val provider = ApolloExternalSchemaLibraryRootsProvider()
-
-    assertEquals(linkedSetOf(externalSchema), ApolloExternalSchemaLibraryRootsProvider.externalSchemaRoots(project))
-    val library = assertOneElement(provider.getAdditionalProjectLibraries(project))
+    val library = assertOneElement(ApolloExternalSchemaLibraryRootsProvider().getAdditionalProjectLibraries(project))
     assertEquals("apollo-external-graphql-schemas", library.comparisonId)
-    assertEquals(listOf(externalSchema), library.sourceRoots)
+    assertEquals(listOf(secondExternalSchema, firstExternalSchema), library.sourceRoots)
     assertEmpty(library.binaryRoots)
     assertEmpty(library.excludedRoots)
     assertFalse(library.isShowInExternalLibrariesNode)
   }
 
   @Test
-  fun missingExternalSchemaParentIsWatched() {
-    val missingSchema = externalDirectory.resolve("generated/schema.graphqls")
-    check(missingSchema.parentFile.mkdir())
-    val internalSchema = myFixture.addFileToProject("graphql/internal.graphqls", "type Query").virtualFile
-    setSchemaPaths(missingSchema.absolutePath, internalSchema.path)
+  fun providerUsesPublishedRootsUntilLibraryChangeRuns() {
+    project.service<GraphQLConfigService>()
+    val firstSchema = createExternalFile("first.graphqls")
+    val secondSchema = createExternalFile("second.graphqls")
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    setSchemaPaths(firstSchema.path)
+    UIUtil.dispatchAllInvocationEvents()
+    assertEquals(listOf(firstSchema), provider.sourceRoots())
 
-    val watchedRoots = ApolloExternalSchemaLibraryRootsProvider().getRootsToWatch(project)
+    setSchemaPaths(secondSchema.path)
 
-    assertEquals(listOf(refresh(missingSchema.parentFile)), watchedRoots)
+    assertEquals(listOf(firstSchema), provider.sourceRoots())
+    UIUtil.dispatchAllInvocationEvents()
+    assertEquals(listOf(secondSchema), provider.sourceRoots())
+  }
+
+  @Test
+  fun watchRequestsAreAddedReplacedAndRemovedBeforeLibraryChange() {
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    val service = project.service<GraphQLConfigService>()
+    val watchRootsDuringChanges = mutableListOf<Collection<VirtualFile>>()
+    val registeredPathsDuringChanges = mutableListOf<Set<String>>()
+    project.messageBus.connect(testRootDisposable).subscribe(
+        AdditionalLibraryRootsListener.TOPIC,
+        AdditionalLibraryRootsListener { _, _, _, _ ->
+          watchRootsDuringChanges += provider.getRootsToWatch(project)
+          registeredPathsDuringChanges += service.registeredWatchRootPaths()
+        },
+    )
+    val firstMissingSchema = externalDirectory.resolve("generated-one/schema.graphqls")
+    val secondMissingSchema = externalDirectory.resolve("generated-two/schema.graphqls")
+    check(firstMissingSchema.parentFile.mkdir())
+    check(secondMissingSchema.parentFile.mkdir())
+    val firstParent = refresh(firstMissingSchema.parentFile)
+    val secondParent = refresh(secondMissingSchema.parentFile)
+
+    setSchemaPaths(firstMissingSchema.absolutePath)
+    UIUtil.dispatchAllInvocationEvents()
+    setSchemaPaths(secondMissingSchema.absolutePath)
+    UIUtil.dispatchAllInvocationEvents()
+    setSchemaPaths()
+    UIUtil.dispatchAllInvocationEvents()
+
+    assertEquals(listOf(firstParent), watchRootsDuringChanges[0])
+    assertEquals(setOf(firstParent.path), registeredPathsDuringChanges[0])
+    assertEquals(listOf(secondParent), watchRootsDuringChanges[1])
+    assertEquals(setOf(secondParent.path), registeredPathsDuringChanges[1])
+    assertEmpty(watchRootsDuringChanges[2])
+    assertEmpty(registeredPathsDuringChanges[2])
+    assertEmpty(provider.getRootsToWatch(project))
+  }
+
+  @Test
+  fun creatingConfiguredSchemaPublishesRoot() {
+    project.service<GraphQLConfigService>()
+    val schemaFile = externalDirectory.resolve("generated/schema.graphqls")
+    check(schemaFile.parentFile.mkdir())
+    val parent = refresh(schemaFile.parentFile)
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    setSchemaPaths(schemaFile.absolutePath)
+    waitForIndexes()
+    assertEquals(listOf(parent), provider.getRootsToWatch(project))
+    assertEmpty(provider.sourceRoots())
+
+    val schema = VfsTestUtil.createFile(parent, schemaFile.name, "type Query")
+    waitForIndexes()
+
+    assertEquals(listOf(schema), provider.sourceRoots())
+    assertTrue(ProjectFileIndex.getInstance(project).isInLibrarySource(schema))
+  }
+
+  @Test
+  fun creatingConfiguredSchemaWithInitiallyMissingParentPublishesRoot() {
+    val service = project.service<GraphQLConfigService>()
+    val schemaFile = externalDirectory.resolve("generated/missing/schema.graphqls")
+    val parentPath = FileUtil.toSystemIndependentName(schemaFile.parentFile.absolutePath)
+    val contentDirectory = externalDirectory.resolve("project-content").also { check(it.mkdir()) }
+    val contentRoot = refresh(contentDirectory)
+    PsiTestUtil.addContentRoot(myFixture.module, contentRoot)
+    val missingContentSchemaPath = "${contentRoot.path}/generated/schema.graphqls"
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    setSchemaPaths(schemaFile.absolutePath, missingContentSchemaPath)
+    waitForIndexes()
+
+    assertFalse(schemaFile.parentFile.exists())
+    assertEmpty(provider.getRootsToWatch(project))
+    assertEquals(setOf(parentPath), service.registeredWatchRootPaths())
+    assertEmpty(provider.sourceRoots())
+
+    check(schemaFile.parentFile.mkdirs())
+    val parent = refresh(schemaFile.parentFile)
+    val schema = VfsTestUtil.createFile(parent, schemaFile.name, "type Query { created: String }")
+    waitForSourceRoot(provider, schema)
+
+    assertEquals(listOf(schema), provider.sourceRoots())
+    assertTrue(ProjectFileIndex.getInstance(project).isInLibrarySource(schema))
+  }
+
+  @Test
+  fun deletingAndRecreatingConfiguredSchemaRefreshesRoots() {
+    project.service<GraphQLConfigService>()
+    val parent = refresh(externalDirectory)
+    val schema = VfsTestUtil.createFile(parent, "schema.graphqls", "type Query")
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    setSchemaPaths(schema.path)
+    waitForIndexes()
+    assertEquals(listOf(schema), provider.sourceRoots())
+    assertTrue(ProjectFileIndex.getInstance(project).isInLibrarySource(schema))
+
+    VfsTestUtil.deleteFile(schema)
+    waitForIndexes()
+    assertFalse(schema.isValid)
+    assertEmpty(provider.sourceRoots())
+
+    val recreatedSchema = VfsTestUtil.createFile(parent, "schema.graphqls", "type Query { recreated: String }")
+    waitForIndexes()
+    assertNotSame(schema, recreatedSchema)
+    assertFalse(schema.isValid)
+    assertTrue(recreatedSchema.isValid)
+    assertEquals(listOf(recreatedSchema), provider.sourceRoots())
+    assertTrue(ProjectFileIndex.getInstance(project).isInLibrarySource(recreatedSchema))
+  }
+
+  @Test
+  fun deletingAndRecreatingConfiguredSchemaParentPublishesNewRoot() {
+    val service = project.service<GraphQLConfigService>()
+    val schemaFile = externalDirectory.resolve("generated/schema.graphqls")
+    check(schemaFile.parentFile.mkdir())
+    val parent = refresh(schemaFile.parentFile)
+    val schema = VfsTestUtil.createFile(parent, schemaFile.name, "type Query")
+    val parentPath = parent.path
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    setSchemaPaths(schema.path)
+    waitForIndexes()
+    assertEquals(listOf(schema), provider.sourceRoots())
+    assertEquals(setOf(parentPath), service.registeredWatchRootPaths())
+
+    VfsTestUtil.deleteFile(parent)
+    waitForIndexes()
+    assertFalse(parent.isValid)
+    assertFalse(schema.isValid)
+    assertEmpty(provider.getRootsToWatch(project))
+    assertEmpty(provider.sourceRoots())
+    assertEquals(setOf(parentPath), service.registeredWatchRootPaths())
+
+    check(schemaFile.parentFile.mkdir())
+    val recreatedParent = refresh(schemaFile.parentFile)
+    val recreatedSchema = VfsTestUtil.createFile(recreatedParent, schemaFile.name, "type Query { recreated: String }")
+    waitForSourceRoot(provider, recreatedSchema)
+
+    assertNotSame(schema, recreatedSchema)
+    assertFalse(schema.isValid)
+    assertTrue(recreatedSchema.isValid)
+    assertEquals(listOf(recreatedSchema), provider.sourceRoots())
+    assertTrue(ProjectFileIndex.getInstance(project).isInLibrarySource(recreatedSchema))
   }
 
   @Test
@@ -73,14 +236,15 @@ class ApolloExternalSchemaLibraryRootsProviderTest : BasePlatformTestCase() {
 
     val provider = ApolloExternalSchemaLibraryRootsProvider()
 
-    assertEmpty(ApolloExternalSchemaLibraryRootsProvider.externalSchemaRoots(project))
     assertEmpty(provider.getAdditionalProjectLibraries(project))
     assertEmpty(provider.getRootsToWatch(project))
   }
 
   @Test
   fun disablingGraphqlConfigurationPublishesRemovedRoots() {
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
     val changes = mutableListOf<Pair<Set<VirtualFile>, Set<VirtualFile>>>()
+    val rootsDuringChanges = mutableListOf<Collection<VirtualFile>>()
     project.service<GraphQLConfigService>()
     project.messageBus.connect(testRootDisposable).subscribe(
         AdditionalLibraryRootsListener.TOPIC,
@@ -92,16 +256,66 @@ class ApolloExternalSchemaLibraryRootsProviderTest : BasePlatformTestCase() {
               libraryNameForDebug: String,
           ) {
             changes += oldRoots.toSet() to newRoots.toSet()
+            rootsDuringChanges += provider.sourceRoots()
           }
         }
     )
     val externalSchema = createExternalFile("schema.graphqls")
     setSchemaPaths(externalSchema.path)
+    UIUtil.dispatchAllInvocationEvents()
     project.projectSettingsState.contributeConfigurationToGraphqlPlugin = false
     UIUtil.dispatchAllInvocationEvents()
 
     assertEquals(setOf(externalSchema), changes.first().second)
+    assertEquals(listOf(externalSchema), rootsDuringChanges.first())
     assertEmpty(changes.last().second)
+    assertEmpty(rootsDuringChanges.last())
+  }
+
+  @Test
+  fun removingConfiguredSchemasPublishesEmptyRoots() {
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+    val rootsDuringChanges = mutableListOf<Collection<VirtualFile>>()
+    project.service<GraphQLConfigService>()
+    project.messageBus.connect(testRootDisposable).subscribe(
+        AdditionalLibraryRootsListener.TOPIC,
+        AdditionalLibraryRootsListener { _, _, _, _ -> rootsDuringChanges += provider.sourceRoots() },
+    )
+    val externalSchema = createExternalFile("schema.graphqls")
+    setSchemaPaths(externalSchema.path)
+    UIUtil.dispatchAllInvocationEvents()
+
+    setSchemaPaths()
+    UIUtil.dispatchAllInvocationEvents()
+
+    assertEquals(listOf(externalSchema), rootsDuringChanges.first())
+    assertEmpty(rootsDuringChanges.last())
+    assertEmpty(provider.sourceRoots())
+  }
+
+  private fun waitForIndexes() {
+    UIUtil.dispatchAllInvocationEvents()
+    IndexingTestUtil.waitUntilIndexesAreReady(project)
+    UIUtil.dispatchAllInvocationEvents()
+  }
+
+  private fun waitForSourceRoot(
+      provider: ApolloExternalSchemaLibraryRootsProvider,
+      schema: VirtualFile,
+  ) {
+    PlatformTestUtil.waitWithEventsDispatching(
+        {
+          val roots = provider.sourceRoots()
+          "Configured schema was not attached after ${schema.parent.path} was created; roots=$roots"
+        },
+        { schema.isValid && provider.sourceRoots().singleOrNull() == schema },
+        30,
+    )
+    waitForIndexes()
+  }
+
+  private fun ApolloExternalSchemaLibraryRootsProvider.sourceRoots(): Collection<VirtualFile> {
+    return getAdditionalProjectLibraries(project).singleOrNull()?.sourceRoots.orEmpty()
   }
 
   private fun setSchemaPaths(vararg paths: String) {

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProviderTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaLibraryRootsProviderTest.kt
@@ -1,0 +1,126 @@
+package com.apollographql.ijplugin.graphql
+
+import com.apollographql.ijplugin.gradle.ApolloKotlinService
+import com.apollographql.ijplugin.gradle.apolloKotlinProjectModelService
+import com.apollographql.ijplugin.settings.projectSettingsState
+import com.intellij.openapi.components.service
+import com.intellij.openapi.roots.AdditionalLibraryRootsListener
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.ui.UIUtil
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.io.File
+
+@RunWith(JUnit4::class)
+class ApolloExternalSchemaLibraryRootsProviderTest : BasePlatformTestCase() {
+  private lateinit var externalDirectory: File
+
+  override fun setUp() {
+    super.setUp()
+    externalDirectory = FileUtil.createTempDirectory("apollo-external-schema", null, true)
+    project.projectSettingsState.contributeConfigurationToGraphqlPlugin = true
+  }
+
+  override fun tearDown() {
+    try {
+      project.projectSettingsState.contributeConfigurationToGraphqlPlugin = true
+      project.apolloKotlinProjectModelService.replaceApolloKotlinServicesForTest(emptyList())
+      UIUtil.dispatchAllInvocationEvents()
+      FileUtil.delete(externalDirectory)
+    } finally {
+      super.tearDown()
+    }
+  }
+
+  @Test
+  fun externalSchemaFilesBecomeSyntheticLibrarySourceRoots() {
+    val internalSchema = myFixture.addFileToProject("graphql/internal.graphqls", "type Query").virtualFile
+    val externalSchema = createExternalFile("schema.graphqls")
+    setSchemaPaths(externalSchema.path, internalSchema.path, externalSchema.path)
+
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+
+    assertEquals(linkedSetOf(externalSchema), ApolloExternalSchemaLibraryRootsProvider.externalSchemaRoots(project))
+    val library = assertOneElement(provider.getAdditionalProjectLibraries(project))
+    assertEquals("apollo-external-graphql-schemas", library.comparisonId)
+    assertEquals(listOf(externalSchema), library.sourceRoots)
+    assertEmpty(library.binaryRoots)
+    assertEmpty(library.excludedRoots)
+    assertFalse(library.isShowInExternalLibrariesNode)
+  }
+
+  @Test
+  fun missingExternalSchemaParentIsWatched() {
+    val missingSchema = externalDirectory.resolve("generated/schema.graphqls")
+    check(missingSchema.parentFile.mkdir())
+    val internalSchema = myFixture.addFileToProject("graphql/internal.graphqls", "type Query").virtualFile
+    setSchemaPaths(missingSchema.absolutePath, internalSchema.path)
+
+    val watchedRoots = ApolloExternalSchemaLibraryRootsProvider().getRootsToWatch(project)
+
+    assertEquals(listOf(refresh(missingSchema.parentFile)), watchedRoots)
+  }
+
+  @Test
+  fun disabledGraphqlConfigurationContributesNoRoots() {
+    val externalSchema = createExternalFile("schema.graphqls")
+    setSchemaPaths(externalSchema.path)
+    project.projectSettingsState.contributeConfigurationToGraphqlPlugin = false
+
+    val provider = ApolloExternalSchemaLibraryRootsProvider()
+
+    assertEmpty(ApolloExternalSchemaLibraryRootsProvider.externalSchemaRoots(project))
+    assertEmpty(provider.getAdditionalProjectLibraries(project))
+    assertEmpty(provider.getRootsToWatch(project))
+  }
+
+  @Test
+  fun disablingGraphqlConfigurationPublishesRemovedRoots() {
+    val changes = mutableListOf<Pair<Set<VirtualFile>, Set<VirtualFile>>>()
+    project.service<GraphQLConfigService>()
+    project.messageBus.connect(testRootDisposable).subscribe(
+        AdditionalLibraryRootsListener.TOPIC,
+        object : AdditionalLibraryRootsListener {
+          override fun libraryRootsChanged(
+              presentableLibraryName: String?,
+              oldRoots: Collection<VirtualFile>,
+              newRoots: Collection<VirtualFile>,
+              libraryNameForDebug: String,
+          ) {
+            changes += oldRoots.toSet() to newRoots.toSet()
+          }
+        }
+    )
+    val externalSchema = createExternalFile("schema.graphqls")
+    setSchemaPaths(externalSchema.path)
+    project.projectSettingsState.contributeConfigurationToGraphqlPlugin = false
+    UIUtil.dispatchAllInvocationEvents()
+
+    assertEquals(setOf(externalSchema), changes.first().second)
+    assertEmpty(changes.last().second)
+  }
+
+  private fun setSchemaPaths(vararg paths: String) {
+    project.apolloKotlinProjectModelService.replaceApolloKotlinServicesForTest(
+        listOf(
+            ApolloKotlinService(
+                gradleProjectPath = ":app",
+                serviceName = "service",
+                allSchemaPaths = paths.toList(),
+            )
+        )
+    )
+  }
+
+  private fun createExternalFile(name: String): VirtualFile {
+    return refresh(externalDirectory.resolve(name).also { it.writeText("type Query") })
+  }
+
+  private fun refresh(file: File): VirtualFile {
+    return checkNotNull(LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file))
+  }
+}

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
@@ -1,5 +1,8 @@
 package com.apollographql.ijplugin.graphql
 
+import com.apollographql.ijplugin.gradle.ApolloKotlinService
+import com.apollographql.ijplugin.gradle.apolloKotlinProjectModelService
+import com.apollographql.ijplugin.settings.projectSettingsState
 import com.apollographql.ijplugin.util.schemaFiles
 import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigContributor
 import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigProvider
@@ -9,12 +12,22 @@ import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawSchemaPointer
 import com.intellij.lang.jsgraphql.ide.config.model.GraphQLConfig
 import com.intellij.lang.jsgraphql.ide.config.model.GraphQLProjectConfig
 import com.intellij.lang.jsgraphql.psi.GraphQLFile
+import com.intellij.lang.jsgraphql.psi.GraphQLIdentifier
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.testFramework.ExtensionTestUtil
+import com.intellij.testFramework.IndexingTestUtil
+import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.builders.EmptyModuleFixtureBuilder
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
 import com.intellij.util.ui.EDT
 import org.junit.Test
@@ -33,14 +46,76 @@ class ApolloExternalSchemaTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBu
     tempDirectory = FileUtil.createTempDirectory("apollo-external-schema", null, true)
     configDirectory = tempDirectory.resolve("project").also { check(it.mkdir()) }
     configDir = refresh(configDirectory)
+    project.projectSettingsState.contributeConfigurationToGraphqlPlugin = true
   }
 
   override fun tearDown() {
     try {
+      project.projectSettingsState.contributeConfigurationToGraphqlPlugin = true
+      project.apolloKotlinProjectModelService.replaceApolloKotlinServicesForTest(emptyList())
+      EDT.dispatchAllInvocationEvents()
       FileUtil.delete(tempDirectory)
     } finally {
       super.tearDown()
     }
+  }
+
+  @Test
+  fun externalSchemaIsIndexedAndResolved() {
+    val schemaVirtualFile = createFile(
+        tempDirectory.resolve("schema.graphqls"),
+        """
+          type Query {
+            externalField: ExternalType!
+          }
+
+          type ExternalType {
+            value: String!
+          }
+        """.trimIndent(),
+    )
+    val projectFileIndex = ProjectFileIndex.getInstance(project)
+    assertFalse(projectFileIndex.isInContent(schemaVirtualFile))
+    assertFalse(projectFileIndex.isInLibrarySource(schemaVirtualFile))
+
+    val operation = myFixture.addFileToProject(
+        "graphql/ExternalQuery.graphql",
+        """
+          query ExternalQuery {
+            externalField {
+              value
+            }
+          }
+        """.trimIndent(),
+    ) as GraphQLFile
+    myFixture.configureFromExistingVirtualFile(operation.virtualFile)
+    val externalField = PsiTreeUtil.findChildrenOfType(operation, GraphQLIdentifier::class.java)
+        .single { it.text == "externalField" }
+
+    project.service<GraphQLConfigService>()
+    project.apolloKotlinProjectModelService.replaceApolloKotlinServicesForTest(
+        listOf(
+            ApolloKotlinService(
+                gradleProjectPath = ":app",
+                serviceName = "service",
+                allSchemaPaths = listOf(schemaVirtualFile.path),
+                allOperationPaths = listOf(myFixture.tempDirPath),
+            )
+        )
+    )
+    EDT.dispatchAllInvocationEvents()
+    val library = assertOneElement(ApolloExternalSchemaLibraryRootsProvider().getAdditionalProjectLibraries(project))
+    assertEquals(listOf(schemaVirtualFile), library.sourceRoots)
+    IndexingTestUtil.waitUntilIndexesAreReady(project)
+    EDT.dispatchAllInvocationEvents()
+
+    val projectConfig = checkNotNull(GraphQLConfigProvider.getInstance(project).resolveProjectConfig(operation))
+    val schemaPsiFile = checkNotNull(PsiManager.getInstance(project).findFile(schemaVirtualFile)) as GraphQLFile
+
+    assertTrue(projectFileIndex.isInLibrarySource(schemaVirtualFile))
+    assertTrue(projectConfig.schemaScope.contains(schemaVirtualFile))
+    assertSame(schemaPsiFile, externalField.reference?.resolve()?.containingFile)
+    assertEquals(listOf(schemaPsiFile), externalField.schemaFiles())
   }
 
   @Test
@@ -124,5 +199,51 @@ class ApolloExternalSchemaTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBu
 
   private fun refresh(file: File): VirtualFile {
     return checkNotNull(LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file))
+  }
+}
+
+@RunWith(JUnit4::class)
+class ApolloExternalSchemaVirtualFileSystemTest : BasePlatformTestCase() {
+  @Test
+  fun schemaFilesResolveRelativePointerFromOriginatingVirtualFileSystem() {
+    val schema = myFixture.addFileToProject("excluded/schema.graphqls", "type Query { field: String }") as GraphQLFile
+    val operation = myFixture.addFileToProject("graphql/operation.graphql", "query Test { field }") as GraphQLFile
+    PsiTestUtil.addExcludedRoot(myFixture.module, checkNotNull(schema.virtualFile.parent))
+    contributeConfig(operation.virtualFile.parent, "../excluded/schema.graphqls")
+    val configProvider = GraphQLConfigProvider.getInstance(project)
+
+    assertNotNull(configProvider.getForConfigFile(operation.virtualFile.parent))
+    assertNotNull(configProvider.resolveProjectConfig(operation))
+    assertFalse(
+        FilenameIndex.getVirtualFilesByName(schema.name, GlobalSearchScope.allScope(project)).contains(schema.virtualFile)
+    )
+
+    val schemaFiles = operation.schemaFiles()
+
+    assertEquals(listOf(schema.virtualFile.path), schemaFiles.map { it.virtualFile.path })
+  }
+
+  private fun contributeConfig(configDir: VirtualFile, vararg schemaPaths: String) {
+    val contributor = object : GraphQLConfigContributor {
+      override fun contributeConfigs(project: Project): Collection<GraphQLConfig> {
+        return listOf(
+            GraphQLConfig(
+                project = project,
+                dir = configDir,
+                file = null,
+                rawData = GraphQLRawConfig(
+                    projects = mapOf(
+                        "service" to GraphQLRawProjectConfig(
+                            schema = schemaPaths.map(::GraphQLRawSchemaPointer),
+                        )
+                    )
+                ),
+            )
+        )
+      }
+    }
+    ExtensionTestUtil.maskExtensions(GraphQLConfigContributor.EP_NAME, listOf(contributor), testRootDisposable)
+    GraphQLConfigProvider.getInstance(project).invalidate()
+    EDT.dispatchAllInvocationEvents()
   }
 }

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
@@ -13,6 +13,7 @@ import com.intellij.lang.jsgraphql.ide.config.model.GraphQLConfig
 import com.intellij.lang.jsgraphql.ide.config.model.GraphQLProjectConfig
 import com.intellij.lang.jsgraphql.psi.GraphQLFile
 import com.intellij.lang.jsgraphql.psi.GraphQLIdentifier
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
@@ -141,7 +142,13 @@ class ApolloExternalSchemaTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBu
     val externalSchema = createFile(tempDirectory.resolve("shared/schema.graphqls"))
     val internalSchema = myFixture.addFileToProject("graphql/schema.graphqls", "type Query { field: String }")
     val operation = myFixture.addFileToProject("graphql/operation.graphql", "query Test { field }") as GraphQLFile
-    contributeConfig(operation.virtualFile.parent, externalSchema.path, "schema.graphqls")
+    contributeGraphQLConfig(
+        project,
+        testRootDisposable,
+        operation.virtualFile.parent,
+        externalSchema.path,
+        "schema.graphqls",
+    )
 
     val schemaFiles = operation.schemaFiles()
 
@@ -149,30 +156,6 @@ class ApolloExternalSchemaTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBu
         listOf(externalSchema.path, internalSchema.virtualFile.path),
         schemaFiles.map { it.virtualFile.path },
     )
-  }
-
-  private fun contributeConfig(configDir: VirtualFile, vararg schemaPaths: String) {
-    val contributor = object : GraphQLConfigContributor {
-      override fun contributeConfigs(project: Project): Collection<GraphQLConfig> {
-        return listOf(
-            GraphQLConfig(
-                project = project,
-                dir = configDir,
-                file = null,
-                rawData = GraphQLRawConfig(
-                    projects = mapOf(
-                        "service" to GraphQLRawProjectConfig(
-                            schema = schemaPaths.map(::GraphQLRawSchemaPointer),
-                        )
-                    )
-                ),
-            )
-        )
-      }
-    }
-    ExtensionTestUtil.maskExtensions(GraphQLConfigContributor.EP_NAME, listOf(contributor), testRootDisposable)
-    GraphQLConfigProvider.getInstance(project).invalidate()
-    EDT.dispatchAllInvocationEvents()
   }
 
   private fun projectConfig(vararg schemaPaths: String): GraphQLProjectConfig {
@@ -209,7 +192,12 @@ class ApolloExternalSchemaVirtualFileSystemTest : BasePlatformTestCase() {
     val schema = myFixture.addFileToProject("excluded/schema.graphqls", "type Query { field: String }") as GraphQLFile
     val operation = myFixture.addFileToProject("graphql/operation.graphql", "query Test { field }") as GraphQLFile
     PsiTestUtil.addExcludedRoot(myFixture.module, checkNotNull(schema.virtualFile.parent))
-    contributeConfig(operation.virtualFile.parent, "../excluded/schema.graphqls")
+    contributeGraphQLConfig(
+        project,
+        testRootDisposable,
+        operation.virtualFile.parent,
+        "../excluded/schema.graphqls",
+    )
     val configProvider = GraphQLConfigProvider.getInstance(project)
 
     assertNotNull(configProvider.getForConfigFile(operation.virtualFile.parent))
@@ -222,28 +210,33 @@ class ApolloExternalSchemaVirtualFileSystemTest : BasePlatformTestCase() {
 
     assertEquals(listOf(schema.virtualFile.path), schemaFiles.map { it.virtualFile.path })
   }
+}
 
-  private fun contributeConfig(configDir: VirtualFile, vararg schemaPaths: String) {
-    val contributor = object : GraphQLConfigContributor {
-      override fun contributeConfigs(project: Project): Collection<GraphQLConfig> {
-        return listOf(
-            GraphQLConfig(
-                project = project,
-                dir = configDir,
-                file = null,
-                rawData = GraphQLRawConfig(
-                    projects = mapOf(
-                        "service" to GraphQLRawProjectConfig(
-                            schema = schemaPaths.map(::GraphQLRawSchemaPointer),
-                        )
-                    )
-                ),
-            )
-        )
-      }
+private fun contributeGraphQLConfig(
+    project: Project,
+    parentDisposable: Disposable,
+    configDir: VirtualFile,
+    vararg schemaPaths: String,
+) {
+  val contributor = object : GraphQLConfigContributor {
+    override fun contributeConfigs(project: Project): Collection<GraphQLConfig> {
+      return listOf(
+          GraphQLConfig(
+              project = project,
+              dir = configDir,
+              file = null,
+              rawData = GraphQLRawConfig(
+                  projects = mapOf(
+                      "service" to GraphQLRawProjectConfig(
+                          schema = schemaPaths.map(::GraphQLRawSchemaPointer),
+                      )
+                  )
+              ),
+          )
+      )
     }
-    ExtensionTestUtil.maskExtensions(GraphQLConfigContributor.EP_NAME, listOf(contributor), testRootDisposable)
-    GraphQLConfigProvider.getInstance(project).invalidate()
-    EDT.dispatchAllInvocationEvents()
   }
+  ExtensionTestUtil.maskExtensions(GraphQLConfigContributor.EP_NAME, listOf(contributor), parentDisposable)
+  GraphQLConfigProvider.getInstance(project).invalidate()
+  EDT.dispatchAllInvocationEvents()
 }

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
@@ -1,21 +1,29 @@
 package com.apollographql.ijplugin.graphql
 
+import com.apollographql.ijplugin.util.schemaFiles
+import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigContributor
+import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigProvider
 import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawConfig
 import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawProjectConfig
 import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawSchemaPointer
 import com.intellij.lang.jsgraphql.ide.config.model.GraphQLConfig
 import com.intellij.lang.jsgraphql.ide.config.model.GraphQLProjectConfig
+import com.intellij.lang.jsgraphql.psi.GraphQLFile
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.ExtensionTestUtil
+import com.intellij.testFramework.builders.EmptyModuleFixtureBuilder
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
+import com.intellij.util.ui.EDT
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.io.File
 
 @RunWith(JUnit4::class)
-class ApolloExternalSchemaTest : BasePlatformTestCase() {
+class ApolloExternalSchemaTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBuilder<*>>() {
   private lateinit var tempDirectory: File
   private lateinit var configDirectory: File
   private lateinit var configDir: VirtualFile
@@ -53,6 +61,45 @@ class ApolloExternalSchemaTest : BasePlatformTestCase() {
     assertTrue(projectConfig.isIncludedOutOfScopeFile(externalSchema))
   }
 
+  @Test
+  fun schemaFilesResolveCanonicalAbsoluteAndRelativePointers() {
+    val externalSchema = createFile(tempDirectory.resolve("shared/schema.graphqls"))
+    val internalSchema = myFixture.addFileToProject("graphql/schema.graphqls", "type Query { field: String }")
+    val operation = myFixture.addFileToProject("graphql/operation.graphql", "query Test { field }") as GraphQLFile
+    contributeConfig(operation.virtualFile.parent, externalSchema.path, "schema.graphqls")
+
+    val schemaFiles = operation.schemaFiles()
+
+    assertEquals(
+        listOf(externalSchema.path, internalSchema.virtualFile.path),
+        schemaFiles.map { it.virtualFile.path },
+    )
+  }
+
+  private fun contributeConfig(configDir: VirtualFile, vararg schemaPaths: String) {
+    val contributor = object : GraphQLConfigContributor {
+      override fun contributeConfigs(project: Project): Collection<GraphQLConfig> {
+        return listOf(
+            GraphQLConfig(
+                project = project,
+                dir = configDir,
+                file = null,
+                rawData = GraphQLRawConfig(
+                    projects = mapOf(
+                        "service" to GraphQLRawProjectConfig(
+                            schema = schemaPaths.map(::GraphQLRawSchemaPointer),
+                        )
+                    )
+                ),
+            )
+        )
+      }
+    }
+    ExtensionTestUtil.maskExtensions(GraphQLConfigContributor.EP_NAME, listOf(contributor), testRootDisposable)
+    GraphQLConfigProvider.getInstance(project).invalidate()
+    EDT.dispatchAllInvocationEvents()
+  }
+
   private fun projectConfig(vararg schemaPaths: String): GraphQLProjectConfig {
     val rootConfig = GraphQLConfig(
         project = project,
@@ -69,9 +116,9 @@ class ApolloExternalSchemaTest : BasePlatformTestCase() {
     return checkNotNull(rootConfig.findProject("service"))
   }
 
-  private fun createFile(file: File): VirtualFile {
+  private fun createFile(file: File, text: String = "type Query"): VirtualFile {
     check(file.parentFile.mkdirs() || file.parentFile.isDirectory)
-    file.writeText("type Query")
+    file.writeText(text)
     return refresh(file)
   }
 

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloExternalSchemaTest.kt
@@ -1,0 +1,81 @@
+package com.apollographql.ijplugin.graphql
+
+import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawConfig
+import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawProjectConfig
+import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawSchemaPointer
+import com.intellij.lang.jsgraphql.ide.config.model.GraphQLConfig
+import com.intellij.lang.jsgraphql.ide.config.model.GraphQLProjectConfig
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.io.File
+
+@RunWith(JUnit4::class)
+class ApolloExternalSchemaTest : BasePlatformTestCase() {
+  private lateinit var tempDirectory: File
+  private lateinit var configDirectory: File
+  private lateinit var configDir: VirtualFile
+
+  override fun setUp() {
+    super.setUp()
+    tempDirectory = FileUtil.createTempDirectory("apollo-external-schema", null, true)
+    configDirectory = tempDirectory.resolve("project").also { check(it.mkdir()) }
+    configDir = refresh(configDirectory)
+  }
+
+  override fun tearDown() {
+    try {
+      FileUtil.delete(tempDirectory)
+    } finally {
+      super.tearDown()
+    }
+  }
+
+  @Test
+  fun parentRelativeSchemaPointerIsIncludedOutOfScopeByCanonicalPath() {
+    val internalSchema = createFile(configDirectory.resolve("schema.graphqls"))
+    val externalSchema = createFile(tempDirectory.resolve("shared/schema.graphqls"))
+    val projectConfig = projectConfig("./../shared/schema.graphqls", "schema.graphqls")
+
+    assertTrue(projectConfig.isIncludedOutOfScopeFile(externalSchema))
+    assertFalse(projectConfig.isIncludedOutOfScopeFile(internalSchema))
+  }
+
+  @Test
+  fun absoluteExternalSchemaPointerIsIncludedOutOfScopeByCanonicalPath() {
+    val externalSchema = createFile(tempDirectory.resolve("shared/schema.graphqls"))
+    val projectConfig = projectConfig(externalSchema.path)
+
+    assertTrue(projectConfig.isIncludedOutOfScopeFile(externalSchema))
+  }
+
+  private fun projectConfig(vararg schemaPaths: String): GraphQLProjectConfig {
+    val rootConfig = GraphQLConfig(
+        project = project,
+        dir = configDir,
+        file = null,
+        rawData = GraphQLRawConfig(
+            projects = mapOf(
+                "service" to GraphQLRawProjectConfig(
+                    schema = schemaPaths.map(::GraphQLRawSchemaPointer),
+                )
+            )
+        ),
+    )
+    return checkNotNull(rootConfig.findProject("service"))
+  }
+
+  private fun createFile(file: File): VirtualFile {
+    check(file.parentFile.mkdirs() || file.parentFile.isDirectory)
+    file.writeText("type Query")
+    return refresh(file)
+  }
+
+  private fun refresh(file: File): VirtualFile {
+    return checkNotNull(LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file))
+  }
+}

--- a/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloGraphQLConfigContributorTest.kt
+++ b/plugin/src/test/kotlin/com/apollographql/ijplugin/graphql/ApolloGraphQLConfigContributorTest.kt
@@ -1,0 +1,68 @@
+package com.apollographql.ijplugin.graphql
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.io.File
+
+@RunWith(JUnit4::class)
+class ApolloGraphQLConfigContributorTest : BasePlatformTestCase() {
+  private lateinit var tempDirectory: File
+  private lateinit var projectDirectory: File
+  private lateinit var projectDir: VirtualFile
+
+  override fun setUp() {
+    super.setUp()
+    tempDirectory = FileUtil.createTempDirectory("apollo-graphql-config-contributor", null, true)
+    projectDirectory = tempDirectory.resolve("project").also { check(it.mkdir()) }
+    projectDir = checkNotNull(LocalFileSystem.getInstance().refreshAndFindFileByIoFile(projectDirectory))
+  }
+
+  override fun tearDown() {
+    try {
+      FileUtil.delete(tempDirectory)
+    } finally {
+      super.tearDown()
+    }
+  }
+
+  @Test
+  fun descendantPathIsProjectRelative() {
+    val descendant = projectDirectory.resolve("module/schema.graphqls").absolutePath
+
+    assertEquals("module/schema.graphqls", descendant.toGraphQLConfigPath(projectDir))
+  }
+
+  @Test
+  fun siblingPathTraversesOutOfProject() {
+    val sibling = tempDirectory.resolve("shared/schema.graphqls").absolutePath
+
+    assertEquals("../shared/schema.graphqls", sibling.toGraphQLConfigPath(projectDir))
+  }
+
+  @Test
+  fun missingPathIsNotEmpty() {
+    val missingGenerated = projectDirectory.resolve("build/generated/schema.graphqls").absolutePath
+
+    assertFalse(missingGenerated.toGraphQLConfigPath(projectDir).isEmpty())
+  }
+
+  @Test
+  fun incompatibleFilesystemRootUsesAbsolutePath() {
+    if (!SystemInfo.isWindows) return
+
+    val projectDrive = projectDirectory.toPath().root.toString().first().uppercaseChar()
+    val alternateDrive = if (projectDrive == 'C') 'D' else 'C'
+    val incompatible = File("$alternateDrive:\\shared\\schema.graphqls")
+
+    assertEquals(
+        FileUtil.toSystemIndependentName(incompatible.absolutePath),
+        incompatible.absolutePath.toGraphQLConfigPath(projectDir)
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Fix external Apollo schema indexing when schema files live outside the opened project root.
- Expose exact schema files as a synthetic library and watch their paths.
- Resolve canonical schema pointers through their originating VFS.

## Testing

- `./gradlew :plugin:test --rerun-tasks --console=plain` — 125 tests
- `./gradlew :plugin:check buildPlugin --console=plain`
- Validated completion and navigation in Android Studio using a pre-symlink Morse worktree
